### PR TITLE
Fix: skip DirectionReaderService and mission target notifications during batch loading

### DIFF
--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/model/registries/combat/MissionsRegistry.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/model/registries/combat/MissionsRegistry.java
@@ -10,6 +10,11 @@ import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableMap;
 import lombok.Data;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Singleton pour stocker les missions globales, observable par la UI
  */
@@ -19,7 +24,7 @@ public class MissionsRegistry {
     private static final MissionsRegistry INSTANCE = new MissionsRegistry();
 
     private final ObservableMap<String, Mission> globalMissionMap =
-            FXCollections.observableHashMap();
+            FXCollections.synchronizedObservableMap(FXCollections.observableHashMap());
 
     public static MissionsRegistry getInstance() {
         return INSTANCE;
@@ -32,24 +37,49 @@ public class MissionsRegistry {
         });
     }
     public void clear(){
-        globalMissionMap.clear();
+        synchronized (globalMissionMap) {
+            globalMissionMap.clear();
+        }
     }
 
     /** Restaure l'ensemble des missions à partir d'un snapshot persisté. */
-    public void applyFullPersistedSnapshot(java.util.Map<String, Mission> snapshot) {
-        globalMissionMap.clear();
-        if (snapshot != null) {
-            globalMissionMap.putAll(snapshot);
+    public void applyFullPersistedSnapshot(Map<String, Mission> snapshot) {
+        synchronized (globalMissionMap) {
+            globalMissionMap.clear();
+            if (snapshot != null) {
+                globalMissionMap.putAll(snapshot);
+            }
         }
     }
 
     public void setActiveMissionsToFailed(){
-        globalMissionMap.forEach((s, mission) -> {
-            if(mission.isActive()){
-                mission.setStatus(MissionStatus.FAILED);
-            }
-        });
+        synchronized (globalMissionMap) {
+            globalMissionMap.forEach((s, mission) -> {
+                if (mission.isActive()) {
+                    mission.setStatus(MissionStatus.FAILED);
+                }
+            });
+        }
         MissionEventNotificationService.getInstance().notifyOnMissionStatusChanged();
+    }
+
+    /**
+     * Snapshot défensif des missions pour itération côté UI (évite les CME
+     * si le journal thread modifie la map en parallèle).
+     */
+    public List<Mission> snapshotMissions() {
+        synchronized (globalMissionMap) {
+            return new ArrayList<>(globalMissionMap.values());
+        }
+    }
+
+    /**
+     * Snapshot défensif de la map missions pour consommation read-only (UI/overlay).
+     */
+    public Map<String, Mission> snapshotMissionMap() {
+        synchronized (globalMissionMap) {
+            return new LinkedHashMap<>(globalMissionMap);
+        }
     }
 
 }

--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/service/CombatMissionHistoryService.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/service/CombatMissionHistoryService.java
@@ -44,8 +44,8 @@ public class CombatMissionHistoryService {
      */
     private void loadCompletedMissions() {
         MissionsRegistry missionsRegistry = MissionsRegistry.getInstance();
-        
-        missionsRegistry.getGlobalMissionMap().values().stream()
+
+        missionsRegistry.snapshotMissions().stream()
                 .filter(mission -> mission.isCompleted() && isCombatMission(mission))
                 .forEach(this::addCompletedMissionToStats);
     }

--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/service/DirectionReaderService.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/service/DirectionReaderService.java
@@ -2,6 +2,7 @@ package be.mirooz.elitedangerous.dashboard.service;
 
 import be.mirooz.elitedangerous.dashboard.view.exploration.RadarComponent;
 import be.mirooz.elitedangerous.dashboard.model.exploration.Position;
+import be.mirooz.elitedangerous.dashboard.view.common.context.DashboardContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import javafx.beans.property.ObjectProperty;
@@ -102,6 +103,9 @@ public class DirectionReaderService {
     private volatile long lastModified = 0;
 
     public void startWatchingStatusFile(double radius,double colonyRangeMeter) {
+        if (DashboardContext.getInstance().isBatchLoading()) {
+            return;
+        }
         if (watching) {
             this.colonyRangeMeter = colonyRangeMeter;
             RadarComponent radarComponent = RadarComponent.getPrimaryInstance();
@@ -192,6 +196,9 @@ public class DirectionReaderService {
      * Arrête la surveillance du fichier Status.json
      */
     public void stopWatchingStatusFile() {
+        if (DashboardContext.getInstance().isBatchLoading()) {
+            return;
+        }
         watching = false;
         if (statusWatcherTask != null){
             statusWatcherTask.cancel(true);

--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/service/DirectionReaderService.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/service/DirectionReaderService.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -44,7 +45,7 @@ public class DirectionReaderService {
     }
 
     @Getter
-    private final List<Position> currentBiologicalSamplePositions = new ArrayList<>();
+    private final List<Position> currentBiologicalSamplePositions = new CopyOnWriteArrayList<>();
     private ScheduledFuture<?> statusWatcherTask;
     // Thread de surveillance
     private volatile boolean watching = false;

--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/service/ExplorationService.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/service/ExplorationService.java
@@ -9,6 +9,7 @@ import be.mirooz.elitedangerous.dashboard.model.registries.commander.CommanderSt
 import be.mirooz.elitedangerous.dashboard.model.registries.exploration.ExplorationDataSaleRegistry;
 import be.mirooz.elitedangerous.dashboard.model.registries.exploration.PlaneteRegistry;
 import be.mirooz.elitedangerous.dashboard.model.registries.exploration.SystemVisitedRegistry;
+import be.mirooz.elitedangerous.dashboard.view.common.context.DashboardContext;
 
 import java.util.*;
 
@@ -113,9 +114,11 @@ public class ExplorationService {
                 }
                 clearCurrentBiologicalAnalysis();
             }
-            Position samplePosition = DirectionReaderService.getInstance().readCurrentPosition(planeteDetail.getRadius());
-            DirectionReaderService.getInstance().getCurrentBiologicalSamplePositions().add(samplePosition);
-            DirectionReaderService.getInstance().startWatchingStatusFile(planeteDetail.getRadius(), species.getColonyRangeMeters());
+            if (!DashboardContext.getInstance().isBatchLoading()) {
+                Position samplePosition = DirectionReaderService.getInstance().readCurrentPosition(planeteDetail.getRadius());
+                DirectionReaderService.getInstance().getCurrentBiologicalSamplePositions().add(samplePosition);
+                DirectionReaderService.getInstance().startWatchingStatusFile(planeteDetail.getRadius(), species.getColonyRangeMeters());
+            }
 
         }
         if (planeteDetail != null && species != null) {

--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/service/MissionService.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/service/MissionService.java
@@ -99,7 +99,7 @@ public class MissionService {
 
     public void updateWantedKillCount(JsonNode jsonNode) {
         String victimFaction = jsonNode.has("VictimFaction") ? jsonNode.get("VictimFaction").asText() : "";
-        if (missionsRegistry.getGlobalMissionMap().values().isEmpty()) {
+        if (missionsRegistry.snapshotMissions().isEmpty()) {
             return;
         }
         List<Mission> eligibleMissions = new ArrayList<>();
@@ -122,7 +122,7 @@ public class MissionService {
 
     public void updatFactionKillCount(JsonNode jsonNode) {
         String victimFaction = jsonNode.has("VictimFaction") ? jsonNode.get("VictimFaction").asText() : "";
-        if (missionsRegistry.getGlobalMissionMap().values().isEmpty()) {
+        if (missionsRegistry.snapshotMissions().isEmpty()) {
             return;
         }
         List<Mission> eligibleMissions = getFactionShipMissions(victimFaction);
@@ -225,7 +225,7 @@ public class MissionService {
 
     @SafeVarargs
     private List<Mission> getEligiblesMissions(String victimFaction, Predicate<Mission>... extraFilters) {
-        Stream<Mission> stream = missionsRegistry.getGlobalMissionMap().values().stream()
+        Stream<Mission> stream = missionsRegistry.snapshotMissions().stream()
                 .filter(mission -> mission.getTargetFaction() != null)
                 .filter(mission -> victimFaction.equals(mission.getTargetFaction()))
                 .filter(mission -> mission.getDestinationSystem() == null ||

--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/service/journal/JournalService.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/service/journal/JournalService.java
@@ -278,7 +278,7 @@ public class JournalService {
             // Rafraîchissement UI global : {@link DashboardService#initActiveMissions()} (finally)
             // après tous les {@code onBatchEnd}, pour respecter l’ordre liaisons → contenus.
         }
-        return new ArrayList<>(missionsRegistry.getGlobalMissionMap().values());
+        return missionsRegistry.snapshotMissions();
 
     }
 

--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/service/listeners/MissionEventNotificationService.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/service/listeners/MissionEventNotificationService.java
@@ -1,5 +1,7 @@
 package be.mirooz.elitedangerous.dashboard.service.listeners;
 
+import be.mirooz.elitedangerous.dashboard.view.common.context.DashboardContext;
+
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -36,6 +38,9 @@ public class MissionEventNotificationService {
     }
 
     public void notifyOnMissionStatusChanged() {
+        if (DashboardContext.getInstance().isBatchLoading()) {
+            return;
+        }
         for (MissionEventListener listener : listeners) {
             try {
                 listener.onStatusChanged();
@@ -45,6 +50,9 @@ public class MissionEventNotificationService {
         }
     }
     public void notifyOnMissionCurrentKillCountChanged() {
+        if (DashboardContext.getInstance().isBatchLoading()) {
+            return;
+        }
         for (MissionEventListener listener : listeners) {
             try {
                 listener.onKillChanged();

--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/service/webservice/CapiApiService.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/service/webservice/CapiApiService.java
@@ -53,6 +53,7 @@ public final class CapiApiService {
 
     private static final CapiApiService INSTANCE = new CapiApiService();
     private static final long MARKET_MIN_INTERVAL_MS = 1000L;
+    private static final long CAPI_SYNC_DELAY_MS = 2_000L;
 
     /**
      * Budget total côté client : le serveur tient 60 s, on relance tant que la somme reste sous ce plafond.
@@ -119,6 +120,9 @@ public final class CapiApiService {
                     .fid(s.getFID())
                     .commanderName(s.getCommanderName())
                     .event(event);
+            if (!waitForCapiSync("/market")) {
+                return;
+            }
             CapiMarketDto response = capiFacade.postMarket(payload);
             handleSuccess(payload, response, journalDockedEvent);
         } catch (UnauthorizedException e) {
@@ -216,6 +220,9 @@ public final class CapiApiService {
         try {
             CommanderStatus status = CommanderStatus.getInstance();
             String language = getCurrentLanguage();
+            if (!waitForCapiSync("/fleetcarrier")) {
+                return;
+            }
             CapiFleetCarrierDto fleetCarrierResponse = capiFacade.fetchFleetCarrier(
                     status.getCommanderName(),
                     status.getFID(),
@@ -241,6 +248,17 @@ public final class CapiApiService {
         return LocalizationService.getInstance().getCurrentLocale() != null
                 ? LocalizationService.getInstance().getCurrentLocale().getLanguage()
                 : Locale.ENGLISH.getLanguage();
+    }
+
+    private boolean waitForCapiSync(String endpoint) {
+        try {
+            Thread.sleep(CAPI_SYNC_DELAY_MS);
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            System.err.println("CAPI " + endpoint + " annulé pendant délai de synchronisation");
+            return false;
+        }
     }
 
     // =========================

--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/view/combat/HeaderController.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/view/combat/HeaderController.java
@@ -109,7 +109,7 @@ public class HeaderController implements Initializable, IRefreshable {
     }
     private void applyFilter(MissionStatus currentFilter, MissionType currentTypeFilter) {
         // Filtrer les missions selon le filtre actuel
-        List<Mission> filteredMissions = missionsRegistry.getGlobalMissionMap().values().stream()
+        List<Mission> filteredMissions = missionsRegistry.snapshotMissions().stream()
                 .filter(Mission::isShipMassacre)
                 .filter(mission -> currentFilter == null || mission.getStatus() == currentFilter)
                 .filter(mission -> currentTypeFilter == null || mission.getType() == currentTypeFilter)

--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/view/combat/MissionListController.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/view/combat/MissionListController.java
@@ -178,7 +178,7 @@ public class MissionListController implements Initializable, IRefreshable, IBatc
 
     private void applyFilter(MissionStatus currentFilter, MissionType currentTypeFilter) {
         boolean isActive = MissionStatus.ACTIVE.equals(currentFilter);
-        List<Mission> filteredMissions = missionsRegistry.getGlobalMissionMap().values().stream()
+        List<Mission> filteredMissions = missionsRegistry.snapshotMissions().stream()
                 .filter(Mission::isShipMassacre)
                 .filter(mission -> currentTypeFilter == null || mission.getType() == currentTypeFilter)
                 .filter(mission -> currentFilter == null || mission.getStatus() == currentFilter)
@@ -313,21 +313,22 @@ public class MissionListController implements Initializable, IRefreshable, IBatc
     private void updateFactionStats(MissionStatus currentStatus, MissionType currentType) {
         // Mettre à jour les statistiques par faction (toujours basées sur les missions actives)
         Map<TargetType, CibleStats> stats = getFactionStats();
+        Map<String, Mission> missionsSnapshot = missionsRegistry.snapshotMissionMap();
 
         // Mettre à jour le panneau de cibles avec les nouvelles statistiques
         if (targetPanel != null) {
-            targetPanel.displayStats(stats, missionsRegistry.getGlobalMissionMap());
+            targetPanel.displayStats(stats, missionsSnapshot);
         }
 
         // Mettre à jour l'overlay s'il est ouvert
         if (targetOverlayComponent.isShowing()) {
-            targetOverlayComponent.updateContent(stats, missionsRegistry.getGlobalMissionMap());
+            targetOverlayComponent.updateContent(stats, missionsSnapshot);
         }
     }
 
     private Map<TargetType, CibleStats> getFactionStats() {
         MissionType currentType = dashboardContext.getCurrentTypeFilter();
-        List<Mission> targetMissions = missionsRegistry.getGlobalMissionMap().values().stream()
+        List<Mission> targetMissions = missionsRegistry.snapshotMissions().stream()
                 .filter(mission -> mission.isShipMassacreActive() || mission.isShipActiveFactionConflictMission())
                 .filter(mission -> currentType == null || currentType.equals(mission.getType()))
                 .collect(Collectors.toList());
@@ -353,7 +354,7 @@ public class MissionListController implements Initializable, IRefreshable, IBatc
     @FXML
     private void showTargetOverlay() {
         Map<TargetType, CibleStats> stats = getFactionStats();
-        Map<String, Mission> missions = missionsRegistry.getGlobalMissionMap();
+        Map<String, Mission> missions = missionsRegistry.snapshotMissionMap();
 
         // Si l'overlay est déjà ouvert, on le ferme
         if (targetOverlayComponent.isShowing()) {

--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/view/combat/TargetOverlayComponent.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/view/combat/TargetOverlayComponent.java
@@ -345,7 +345,7 @@ public class TargetOverlayComponent {
             
             // Calculer les pending credits
             // 🔒 SNAPSHOT pour éviter ConcurrentModificationException
-            List<Mission> missionsSnapshot = new ArrayList<>(missionsRegistry.getGlobalMissionMap().values());
+            List<Mission> missionsSnapshot = missionsRegistry.snapshotMissions();
             long pendingCredits = missionsSnapshot.stream()
                     .filter(Mission::isPending)
                     .mapToLong(Mission::getReward)

--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/view/exploration/RadarComponent.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/view/exploration/RadarComponent.java
@@ -289,7 +289,8 @@ public class RadarComponent {
     }
 
     private void drawBiologicalSamples(Position currentPos, double centerX, double centerY, double radius) {
-        List<Position> samplePositions = directionService.getCurrentBiologicalSamplePositions();
+        List<Position> samplePositions =
+                new ArrayList<>(directionService.getCurrentBiologicalSamplePositions());
         Double colonyRangeMeter = directionService.getColonyRangeMeter();
 
         if (samplePositions == null || samplePositions.isEmpty()) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Prevent UI/event emissions during journal batch replay (`DashboardContext.isBatchLoading() == true`) for both:
- direction tracking flows, and
- mission target/kill updates in the left missions panel.

Also harden mission-panel and radar rendering paths against concurrent modification while journal parsing and UI refresh happen in parallel.

Changes included:

### Direction flow
- Guard `DirectionReaderService.startWatchingStatusFile(...)` during batch loading.
- Guard `DirectionReaderService.stopWatchingStatusFile()` during batch loading.
- Guard `ExplorationService.setCurrentBiologicalAnalysis(...)` to skip status position read/watch startup during batch loading.

### Mission targets / left panel flow
- Guard `MissionEventNotificationService.notifyOnMissionStatusChanged()` during batch loading.
- Guard `MissionEventNotificationService.notifyOnMissionCurrentKillCountChanged()` during batch loading.

### Concurrency safety (radar samples)
- Use a snapshot copy before iterating biological samples in `RadarComponent`:
  - `new ArrayList<>(directionService.getCurrentBiologicalSamplePositions())`
- Back `DirectionReaderService.currentBiologicalSamplePositions` with `CopyOnWriteArrayList`.

### Concurrency safety (missions panel CME)
- `MissionsRegistry.globalMissionMap` is now wrapped with `FXCollections.synchronizedObservableMap(...)`.
- Added thread-safe snapshot helpers in `MissionsRegistry`:
  - `snapshotMissions()`
  - `snapshotMissionMap()`
- Updated `MissionListController` to consume snapshots instead of iterating directly over `getGlobalMissionMap().values()` in:
  - mission filtering
  - faction stats computation
  - target panel update
  - target overlay opening/update

### Concurrency safety (broader combat flows)
- Replaced direct mission-map iteration with registry snapshots in:
  - `MissionService`
  - `CombatMissionHistoryService`
  - `HeaderController`
  - `TargetOverlayComponent` (pending credits block)
  - `JournalService` return path (`parseAllJournalFiles`)

### CAPI synchronization delay
- Added a centralized 2-second delay before CAPI calls:
  - before `/market` (`postMarket`)
  - before `/fleetcarrier` (`fetchFleetCarrier`)
- Implemented via `waitForCapiSync(...)` in `CapiApiService`.

This addresses the reported stack trace crash:
`ConcurrentModificationException` in `MissionListController.getFactionStats(...)`, reduces similar risks in adjacent combat UI/services, and adds the requested CAPI sync buffer.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation or other (no code change)

## Related issues

Fixes #N/A
(Optional) Relates to #N/A

## Checklist

- [x] My code follows the existing style of the project
- [ ] I have run `mvn clean install` successfully
- [ ] I have tested my changes (e.g. ran the app and verified behavior)
- [ ] For UI or user-facing text: I updated `messages_en.properties` and `messages_fr.properties` if needed

## Screenshots or notes (optional)

Validation could not be executed in this cloud environment because Maven is not installed (`mvn: command not found`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-304542eb-8240-4287-8768-db2c10aecca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-304542eb-8240-4287-8768-db2c10aecca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

