### PR TITLE
Ajout d'un simulateur de lignes journal exploration

### DIFF
--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/tools/ExplorationJournalEventSimulatorTool.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/tools/ExplorationJournalEventSimulatorTool.java
@@ -1,0 +1,650 @@
+package be.mirooz.elitedangerous.dashboard.tools;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Stream;
+
+/**
+ * Outil CLI de simulation des événements journal orientés exploration.
+ * <p>
+ * Écrit une ligne JSON dans le dernier Journal.*.log existant.
+ */
+public class ExplorationJournalEventSimulatorTool {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final String EVENT_FSD_JUMP = "fsdjump";
+    private static final String EVENT_SCAN = "scan";
+    private static final String EVENT_SCAN_ORGANIC = "scanorganic";
+    private static final String EVENT_DOCKED = "docked";
+
+    private static final List<String> SYSTEM_PREFIXES = List.of(
+            "Swoilz", "Dryooe", "Bleia", "Hypua", "Prua", "Trifid"
+    );
+
+    private final Random random;
+
+    public ExplorationJournalEventSimulatorTool() {
+        this(new Random());
+    }
+
+    ExplorationJournalEventSimulatorTool(Random random) {
+        this.random = Objects.requireNonNull(random, "random");
+    }
+
+    public static void main(String[] args) {
+        try {
+            CliInput input = CliInput.parse(args);
+            if (input == null) {
+                printUsage();
+                return;
+            }
+
+            ExplorationJournalEventSimulatorTool tool = new ExplorationJournalEventSimulatorTool();
+            Path journal = tool.simulateAndAppend(input.eventType(), input.journalDirectory(), input.options());
+            System.out.println("Evenement ajoute dans " + journal + " : " + input.eventType());
+        } catch (Exception e) {
+            System.err.println("Erreur simulation journal: " + e.getMessage());
+            printUsage();
+            System.exit(1);
+        }
+    }
+
+    public Path simulateAndAppend(String eventType, Path journalDirectory, Map<String, String> options) throws IOException {
+        String normalizedEvent = normalizeEventType(eventType);
+        Path latestJournal = findLatestJournalFile(journalDirectory);
+        JournalContext context = buildContextFromJournal(latestJournal);
+
+        ObjectNode eventNode = switch (normalizedEvent) {
+            case EVENT_FSD_JUMP -> createFsdJumpEvent(context, options);
+            case EVENT_SCAN -> createScanEvent(context, options);
+            case EVENT_SCAN_ORGANIC -> createScanOrganicEvent(context, options);
+            case EVENT_DOCKED -> createDockedEvent(context, options);
+            default -> throw new IllegalArgumentException("Type d'evenement non supporte: " + eventType);
+        };
+
+        appendJsonLine(latestJournal, OBJECT_MAPPER.writeValueAsString(eventNode));
+        return latestJournal;
+    }
+
+    private static String normalizeEventType(String eventType) {
+        if (eventType == null) {
+            throw new IllegalArgumentException("Le type d'evenement est obligatoire");
+        }
+        return eventType.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private Path findLatestJournalFile(Path journalDirectory) throws IOException {
+        if (journalDirectory == null || !Files.isDirectory(journalDirectory)) {
+            throw new IllegalArgumentException("Dossier journal invalide: " + journalDirectory);
+        }
+
+        try (Stream<Path> files = Files.list(journalDirectory)) {
+            return files
+                    .filter(Files::isRegularFile)
+                    .filter(p -> {
+                        String fileName = p.getFileName().toString();
+                        return fileName.startsWith("Journal.") && fileName.endsWith(".log");
+                    })
+                    .max(Comparator.comparing(path -> path.getFileName().toString()))
+                    .orElseThrow(() -> new IllegalArgumentException("Aucun fichier Journal.*.log trouve dans " + journalDirectory));
+        }
+    }
+
+    private JournalContext buildContextFromJournal(Path journalFile) throws IOException {
+        JournalContext context = new JournalContext();
+        List<String> lines = Files.readAllLines(journalFile, StandardCharsets.UTF_8);
+
+        for (String rawLine : lines) {
+            String line = rawLine == null ? "" : rawLine.trim();
+            if (!line.startsWith("{")) {
+                continue;
+            }
+
+            JsonNode node;
+            try {
+                node = OBJECT_MAPPER.readTree(line);
+            } catch (Exception ignored) {
+                continue;
+            }
+
+            context.lastTimestamp = extractTimestamp(node).orElse(context.lastTimestamp);
+            String event = node.path("event").asText("");
+
+            if ("FSDJump".equals(event) || "Location".equals(event) || "Docked".equals(event)) {
+                updateCurrentSystem(context, node);
+            }
+            if ("Docked".equals(event)) {
+                context.lastDockedStarSystem = textValue(node, "StarSystem");
+                context.lastDockedSystemAddress = node.path("SystemAddress").asLong(0L);
+            }
+
+            updateMaxBodyIdFromNode(context, node);
+
+            if ("Scan".equals(event) && node.has("PlanetClass")) {
+                buildPlanetFromScan(node).ifPresent(planet -> registerPlanet(context, planet));
+            } else if (isPlanetProximityEvent(event, node)) {
+                buildPlanetFromGenericBodyEvent(node).ifPresent(planet -> registerPlanet(context, planet));
+            }
+        }
+
+        if (context.currentStarSystem == null && context.lastScannedPlanet != null) {
+            context.currentStarSystem = context.lastScannedPlanet.starSystem;
+            context.currentSystemAddress = context.lastScannedPlanet.systemAddress;
+        }
+        if (context.currentSystemAddress <= 0 && context.currentStarSystem != null) {
+            PlanetContext planet = context.lastPlanetBySystem.get(key(context.currentStarSystem));
+            if (planet != null) {
+                context.currentSystemAddress = planet.systemAddress;
+            }
+        }
+        return context;
+    }
+
+    private static Optional<Instant> extractTimestamp(JsonNode node) {
+        String value = textValue(node, "timestamp");
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(Instant.parse(value));
+        } catch (Exception ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private static boolean isPlanetProximityEvent(String event, JsonNode node) {
+        if (!List.of("Touchdown", "SupercruiseExit", "Embark", "Disembark").contains(event)) {
+            return false;
+        }
+        if (!node.has("BodyID") || !node.has("StarSystem")) {
+            return false;
+        }
+        return "Planet".equalsIgnoreCase(node.path("BodyType").asText("")) || node.path("OnPlanet").asBoolean(false);
+    }
+
+    private static Optional<PlanetContext> buildPlanetFromScan(JsonNode node) {
+        if (!node.has("BodyID") || !node.has("StarSystem")) {
+            return Optional.empty();
+        }
+        int bodyId = node.path("BodyID").asInt(-1);
+        if (bodyId < 0) {
+            return Optional.empty();
+        }
+        String starSystem = textValue(node, "StarSystem");
+        if (starSystem == null || starSystem.isBlank()) {
+            return Optional.empty();
+        }
+        long systemAddress = node.path("SystemAddress").asLong(0L);
+        String bodyName = textValue(node, "BodyName");
+        if (bodyName == null || bodyName.isBlank()) {
+            bodyName = starSystem + " Body " + bodyId;
+        }
+        return Optional.of(new PlanetContext(bodyName, bodyId, starSystem, systemAddress));
+    }
+
+    private static Optional<PlanetContext> buildPlanetFromGenericBodyEvent(JsonNode node) {
+        int bodyId = node.path("BodyID").asInt(-1);
+        if (bodyId < 0) {
+            return Optional.empty();
+        }
+        String starSystem = textValue(node, "StarSystem");
+        if (starSystem == null || starSystem.isBlank()) {
+            return Optional.empty();
+        }
+        long systemAddress = node.path("SystemAddress").asLong(0L);
+        String bodyName = textValue(node, "Body");
+        if (bodyName == null || bodyName.isBlank()) {
+            bodyName = starSystem + " Body " + bodyId;
+        }
+        return Optional.of(new PlanetContext(bodyName, bodyId, starSystem, systemAddress));
+    }
+
+    private static void registerPlanet(JournalContext context, PlanetContext planet) {
+        context.lastScannedPlanet = planet;
+        context.lastPlanetBySystem.put(key(planet.starSystem), planet);
+        int currentMax = context.maxBodyIdBySystem.getOrDefault(key(planet.starSystem), 0);
+        context.maxBodyIdBySystem.put(key(planet.starSystem), Math.max(currentMax, planet.bodyId));
+    }
+
+    private static void updateCurrentSystem(JournalContext context, JsonNode node) {
+        String starSystem = textValue(node, "StarSystem");
+        if (starSystem != null && !starSystem.isBlank()) {
+            context.currentStarSystem = starSystem;
+        }
+        long address = node.path("SystemAddress").asLong(0L);
+        if (address > 0) {
+            context.currentSystemAddress = address;
+        }
+    }
+
+    private static void updateMaxBodyIdFromNode(JournalContext context, JsonNode node) {
+        String starSystem = textValue(node, "StarSystem");
+        int bodyId = node.path("BodyID").asInt(-1);
+        if (starSystem == null || starSystem.isBlank() || bodyId < 0) {
+            return;
+        }
+        String systemKey = key(starSystem);
+        int currentMax = context.maxBodyIdBySystem.getOrDefault(systemKey, 0);
+        context.maxBodyIdBySystem.put(systemKey, Math.max(currentMax, bodyId));
+    }
+
+    private ObjectNode createFsdJumpEvent(JournalContext context, Map<String, String> options) {
+        String currentSystem = context.currentStarSystem == null ? "Simulation Seed" : context.currentStarSystem;
+        String newSystem = options.getOrDefault("system", generateNextSystemName(currentSystem));
+        if (newSystem.equalsIgnoreCase(currentSystem)) {
+            newSystem = newSystem + " Next";
+        }
+        long systemAddress = parseLongOption(options, "system-address")
+                .orElseGet(() -> generateDifferentAddress(context.currentSystemAddress));
+
+        ObjectNode node = createBaseEvent("FSDJump", context, options);
+        node.put("Taxi", false);
+        node.put("Multicrew", false);
+        node.put("StarSystem", newSystem);
+        node.put("SystemAddress", systemAddress);
+
+        ArrayNode starPos = node.putArray("StarPos");
+        starPos.add(round(randomInRange(-1400.0, 1400.0), 5));
+        starPos.add(round(randomInRange(-900.0, 900.0), 5));
+        starPos.add(round(randomInRange(-1500.0, 1500.0), 5));
+
+        node.put("SystemAllegiance", "");
+        node.put("SystemEconomy", "$economy_None;");
+        node.put("SystemEconomy_Localised", "Aucune");
+        node.put("SystemSecondEconomy", "$economy_None;");
+        node.put("SystemSecondEconomy_Localised", "Aucune");
+        node.put("SystemGovernment", "$government_None;");
+        node.put("SystemGovernment_Localised", "Aucune");
+        node.put("SystemSecurity", "$GAlAXY_MAP_INFO_state_anarchy;");
+        node.put("SystemSecurity_Localised", "Anarchie");
+        node.put("Population", 0);
+        node.put("Body", newSystem + " A");
+        node.put("BodyID", 1);
+        node.put("BodyType", "Star");
+        node.put("JumpDist", round(randomInRange(18.0, 82.0), 3));
+        node.put("FuelUsed", round(randomInRange(2.1, 5.8), 6));
+        node.put("FuelLevel", round(randomInRange(8.0, 31.0), 6));
+        return node;
+    }
+
+    private ObjectNode createScanEvent(JournalContext context, Map<String, String> options) {
+        String starSystem = options.getOrDefault("system", defaultSystemName(context));
+        long systemAddress = parseLongOption(options, "system-address")
+                .orElseGet(() -> resolveSystemAddressForSystem(context, starSystem));
+
+        int bodyId = parseIntOption(options, "body-id")
+                .orElseGet(() -> nextBodyIdForSystem(context, starSystem));
+        String bodyName = options.getOrDefault("body-name", starSystem + " A " + bodyId);
+
+        ObjectNode node = createBaseEvent("Scan", context, options);
+        node.put("ScanType", options.getOrDefault("scan-type", "Detailed"));
+        node.put("BodyName", bodyName);
+        node.put("BodyID", bodyId);
+
+        ArrayNode parents = node.putArray("Parents");
+        parents.addObject().put("Star", 1);
+        parents.addObject().put("Null", 0);
+
+        node.put("StarSystem", starSystem);
+        node.put("SystemAddress", systemAddress);
+        node.put("DistanceFromArrivalLS", round(randomInRange(30.0, 3200.0), 6));
+        node.put("TidalLock", random.nextBoolean());
+        node.put("TerraformState", "");
+        node.put("PlanetClass", options.getOrDefault("planet-class", "High metal content body"));
+        node.put("Atmosphere", "");
+        node.put("AtmosphereType", "None");
+        node.put("Volcanism", "");
+        node.put("MassEM", round(randomInRange(0.001, 0.008), 6));
+        node.put("Radius", round(randomInRange(650000.0, 1450000.0), 6));
+        node.put("SurfaceGravity", round(randomInRange(0.95, 2.15), 6));
+        node.put("SurfaceTemperature", round(randomInRange(90.0, 610.0), 6));
+        node.put("SurfacePressure", 0.0);
+        node.put("Landable", true);
+
+        ArrayNode materials = node.putArray("Materials");
+        materials.addObject()
+                .put("Name", "iron")
+                .put("Name_Localised", "Fer")
+                .put("Percent", round(randomInRange(18.0, 25.0), 6));
+        materials.addObject()
+                .put("Name", "nickel")
+                .put("Percent", round(randomInRange(12.0, 18.0), 6));
+        materials.addObject()
+                .put("Name", "sulphur")
+                .put("Name_Localised", "Soufre")
+                .put("Percent", round(randomInRange(9.0, 17.0), 6));
+
+        ObjectNode composition = node.putObject("Composition");
+        composition.put("Ice", 0.0);
+        composition.put("Rock", round(randomInRange(0.60, 0.75), 6));
+        composition.put("Metal", round(1.0 - composition.path("Rock").asDouble(), 6));
+
+        node.put("SemiMajorAxis", randomInRange(1.2E9, 7.9E9));
+        node.put("Eccentricity", round(randomInRange(0.0002, 0.0087), 6));
+        node.put("OrbitalInclination", round(randomInRange(-1.5, 1.5), 6));
+        node.put("Periapsis", round(randomInRange(10.0, 350.0), 6));
+        node.put("OrbitalPeriod", randomInRange(150000.0, 1650000.0));
+        node.put("AscendingNode", round(randomInRange(-170.0, 170.0), 6));
+        node.put("MeanAnomaly", round(randomInRange(0.0, 359.9), 6));
+        node.put("RotationPeriod", randomInRange(145000.0, 1700000.0));
+        node.put("AxialTilt", round(randomInRange(-1.5, 1.5), 6));
+        node.put("WasDiscovered", false);
+        node.put("WasMapped", false);
+        node.put("WasFootfalled", false);
+        return node;
+    }
+
+    private ObjectNode createScanOrganicEvent(JournalContext context, Map<String, String> options) {
+        PlanetContext organicTarget = resolveOrganicTargetPlanet(context)
+                .orElseGet(() -> new PlanetContext(
+                        defaultSystemName(context) + " A " + nextBodyIdForSystem(context, defaultSystemName(context)),
+                        nextBodyIdForSystem(context, defaultSystemName(context)),
+                        defaultSystemName(context),
+                        resolveSystemAddressForSystem(context, defaultSystemName(context))
+                ));
+
+        int bodyId = parseIntOption(options, "body-id").orElse(organicTarget.bodyId);
+        long systemAddress = parseLongOption(options, "system-address").orElse(organicTarget.systemAddress);
+
+        ObjectNode node = createBaseEvent("ScanOrganic", context, options);
+        node.put("ScanType", options.getOrDefault("scan-type", "Log"));
+        node.put("Genus", "$Codex_Ent_Stratum_Genus_Name;");
+        node.put("Genus_Localised", "Stratum");
+        node.put("Species", "$Codex_Ent_Stratum_07_Name;");
+        node.put("Species_Localised", "Stratum Tectonicas");
+        node.put("Variant", "$Codex_Ent_Stratum_07_L_Name;");
+        node.put("Variant_Localised", "Stratum Tectonicas - Turquoise");
+        node.put("WasLogged", false);
+        node.put("SystemAddress", systemAddress);
+        node.put("Body", bodyId);
+        return node;
+    }
+
+    private ObjectNode createDockedEvent(JournalContext context, Map<String, String> options) {
+        String starSystem = options.getOrDefault("system", defaultSystemName(context));
+        long systemAddress = parseLongOption(options, "system-address")
+                .orElseGet(() -> resolveSystemAddressForSystem(context, starSystem));
+
+        ObjectNode node = createBaseEvent("Docked", context, options);
+        node.put("StationName", options.getOrDefault("station-name", "Warboard Simulation Port"));
+        node.put("StationType", options.getOrDefault("station-type", "Coriolis"));
+        node.put("Taxi", false);
+        node.put("Multicrew", false);
+        node.put("StarSystem", starSystem);
+        node.put("SystemAddress", systemAddress);
+        node.put("MarketID", parseLongOption(options, "market-id").orElse(Math.abs(random.nextLong(9_999_999_999L))));
+        node.putObject("StationFaction").put("Name", "Pilots Federation Local Branch");
+        node.put("StationGovernment", "$government_Democracy;");
+        node.put("StationGovernment_Localised", "Democratie");
+        node.put("StationAllegiance", "PilotsFederation");
+
+        ArrayNode services = node.putArray("StationServices");
+        services.add("dock");
+        services.add("autodock");
+        services.add("contacts");
+        services.add("exploration");
+        services.add("stationMenu");
+
+        node.put("StationEconomy", "$economy_HighTech;");
+        node.put("StationEconomy_Localised", "Haute Technologie");
+        node.put("DistFromStarLS", round(randomInRange(15.0, 1200.0), 3));
+        return node;
+    }
+
+    private Optional<PlanetContext> resolveOrganicTargetPlanet(JournalContext context) {
+        if (context.lastDockedStarSystem != null && !context.lastDockedStarSystem.isBlank()) {
+            PlanetContext fromDockedSystem = context.lastPlanetBySystem.get(key(context.lastDockedStarSystem));
+            if (fromDockedSystem != null) {
+                return Optional.of(fromDockedSystem);
+            }
+        }
+        return Optional.ofNullable(context.lastScannedPlanet);
+    }
+
+    private ObjectNode createBaseEvent(String eventName, JournalContext context, Map<String, String> options) {
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
+        node.put("timestamp", options.getOrDefault("timestamp", nextTimestamp(context)));
+        node.put("event", eventName);
+        return node;
+    }
+
+    private String nextTimestamp(JournalContext context) {
+        Instant base = context.lastTimestamp == null ? Instant.now() : context.lastTimestamp.plusSeconds(1);
+        return base.truncatedTo(ChronoUnit.SECONDS).toString();
+    }
+
+    private String defaultSystemName(JournalContext context) {
+        if (context.currentStarSystem != null && !context.currentStarSystem.isBlank()) {
+            return context.currentStarSystem;
+        }
+        if (context.lastScannedPlanet != null && context.lastScannedPlanet.starSystem != null) {
+            return context.lastScannedPlanet.starSystem;
+        }
+        return "Simulation Alpha";
+    }
+
+    private long resolveSystemAddressForSystem(JournalContext context, String starSystem) {
+        if (starSystem != null && context.currentStarSystem != null
+                && starSystem.equalsIgnoreCase(context.currentStarSystem)
+                && context.currentSystemAddress > 0) {
+            return context.currentSystemAddress;
+        }
+        PlanetContext bySystem = context.lastPlanetBySystem.get(key(starSystem));
+        if (bySystem != null && bySystem.systemAddress > 0) {
+            return bySystem.systemAddress;
+        }
+        if (context.lastDockedStarSystem != null && context.lastDockedStarSystem.equalsIgnoreCase(starSystem)
+                && context.lastDockedSystemAddress > 0) {
+            return context.lastDockedSystemAddress;
+        }
+        return generateDifferentAddress(context.currentSystemAddress);
+    }
+
+    private int nextBodyIdForSystem(JournalContext context, String starSystem) {
+        int current = context.maxBodyIdBySystem.getOrDefault(key(starSystem), 0);
+        return Math.max(1, current + 1);
+    }
+
+    private String generateNextSystemName(String currentSystem) {
+        String prefix = SYSTEM_PREFIXES.get(random.nextInt(SYSTEM_PREFIXES.size()));
+        String code = randomUpperCase(2) + "-" + randomUpperCase(1);
+        String suffix = " " + random.nextInt(80) + "-" + random.nextInt(10);
+        String candidate = prefix + " " + code + suffix;
+        if (candidate.equalsIgnoreCase(currentSystem)) {
+            return candidate + " A";
+        }
+        return candidate;
+    }
+
+    private String randomUpperCase(int size) {
+        StringBuilder sb = new StringBuilder(size);
+        for (int i = 0; i < size; i++) {
+            sb.append((char) ('A' + random.nextInt(26)));
+        }
+        return sb.toString();
+    }
+
+    private long generateDifferentAddress(long existingAddress) {
+        long value = Math.abs(random.nextLong(9_000_000_000_000L)) + 10_000_000_000L;
+        if (value == existingAddress) {
+            return value + 37L;
+        }
+        return value;
+    }
+
+    private static Optional<Long> parseLongOption(Map<String, String> options, String key) {
+        String value = options.get(key);
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(Long.parseLong(value));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Option numerique invalide --" + key + "=" + value);
+        }
+    }
+
+    private static Optional<Integer> parseIntOption(Map<String, String> options, String key) {
+        String value = options.get(key);
+        if (value == null || value.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(Integer.parseInt(value));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Option numerique invalide --" + key + "=" + value);
+        }
+    }
+
+    private void appendJsonLine(Path journalFile, String jsonLine) throws IOException {
+        StringBuilder data = new StringBuilder();
+        if (Files.size(journalFile) > 0 && !endsWithLineBreak(journalFile)) {
+            data.append(System.lineSeparator());
+        }
+        data.append(jsonLine).append(System.lineSeparator());
+        Files.writeString(journalFile, data.toString(), StandardCharsets.UTF_8, StandardOpenOption.APPEND);
+    }
+
+    private boolean endsWithLineBreak(Path journalFile) throws IOException {
+        try (RandomAccessFile raf = new RandomAccessFile(journalFile.toFile(), "r")) {
+            long length = raf.length();
+            if (length == 0) {
+                return false;
+            }
+            raf.seek(length - 1);
+            int lastByte = raf.read();
+            return lastByte == '\n' || lastByte == '\r';
+        }
+    }
+
+    private static String key(String starSystem) {
+        return starSystem == null ? "" : starSystem.toLowerCase(Locale.ROOT);
+    }
+
+    private static String textValue(JsonNode node, String fieldName) {
+        if (node == null || fieldName == null) {
+            return null;
+        }
+        JsonNode value = node.get(fieldName);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        String text = value.asText();
+        return text == null || text.isBlank() ? null : text;
+    }
+
+    private double randomInRange(double min, double max) {
+        return min + (max - min) * random.nextDouble();
+    }
+
+    private static double round(double value, int scale) {
+        double factor = Math.pow(10, scale);
+        return Math.round(value * factor) / factor;
+    }
+
+    private static void printUsage() {
+        System.out.println("""
+                Usage:
+                  mvn -pl elite-warboard-missions exec:java -Dexec.mainClass=be.mirooz.elitedangerous.dashboard.tools.ExplorationJournalEventSimulatorTool -Dexec.args="<event> [--journal-dir=PATH] [--key=value]"
+
+                Events supportes:
+                  fsdjump
+                  scan
+                  scanorganic
+                  docked
+
+                Exemples:
+                  ... -Dexec.args="fsdjump --journal-dir=elite-warboard-missions/src/main/resources/exemple"
+                  ... -Dexec.args="scan --scan-type=Detailed"
+                  ... -Dexec.args="scanorganic --scan-type=Sample"
+                """);
+    }
+
+    private record CliInput(String eventType, Path journalDirectory, Map<String, String> options) {
+        static CliInput parse(String[] args) {
+            if (args == null || args.length == 0) {
+                return null;
+            }
+            String eventType = normalizeEventType(args[0]);
+            if ("help".equals(eventType) || "--help".equals(eventType) || "-h".equals(eventType)) {
+                return null;
+            }
+
+            Map<String, String> options = new HashMap<>();
+            for (int i = 1; i < args.length; i++) {
+                String token = args[i];
+                if (token == null || token.isBlank()) {
+                    continue;
+                }
+                if (!token.startsWith("--") || !token.contains("=")) {
+                    throw new IllegalArgumentException("Argument invalide: " + token);
+                }
+                int eq = token.indexOf('=');
+                String key = token.substring(2, eq).trim().toLowerCase(Locale.ROOT);
+                String value = token.substring(eq + 1).trim();
+                options.put(key, value);
+            }
+
+            Path journalDirectory = resolveJournalDirectory(options.get("journal-dir"));
+            return new CliInput(eventType, journalDirectory, Map.copyOf(options));
+        }
+
+        private static Path resolveJournalDirectory(String configuredPath) {
+            if (configuredPath != null && !configuredPath.isBlank()) {
+                return Path.of(configuredPath);
+            }
+
+            List<Path> candidates = new ArrayList<>();
+            candidates.add(Path.of("src/main/resources/exemple"));
+            candidates.add(Path.of("elite-warboard-missions/src/main/resources/exemple"));
+            candidates.add(Path.of(
+                    System.getProperty("user.home"),
+                    "Saved Games",
+                    "Frontier Developments",
+                    "Elite Dangerous"
+            ));
+
+            return candidates.stream()
+                    .filter(Files::isDirectory)
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "Aucun dossier journal detecte automatiquement; utilisez --journal-dir=..."
+                    ));
+        }
+    }
+
+    private static final class JournalContext {
+        private String currentStarSystem;
+        private long currentSystemAddress;
+        private String lastDockedStarSystem;
+        private long lastDockedSystemAddress;
+        private PlanetContext lastScannedPlanet;
+        private Instant lastTimestamp;
+        private final Map<String, PlanetContext> lastPlanetBySystem = new HashMap<>();
+        private final Map<String, Integer> maxBodyIdBySystem = new HashMap<>();
+    }
+
+    private record PlanetContext(String bodyName, int bodyId, String starSystem, long systemAddress) {
+    }
+}

--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/tools/ExplorationJournalEventSimulatorTool.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/tools/ExplorationJournalEventSimulatorTool.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
@@ -41,6 +43,7 @@ public class ExplorationJournalEventSimulatorTool {
     private static final List<String> SYSTEM_PREFIXES = List.of(
             "Swoilz", "Dryooe", "Bleia", "Hypua", "Prua", "Trifid"
     );
+    private static final List<String> STAR_TYPES = List.of("M", "K", "G", "F", "A");
 
     private final Random random;
 
@@ -141,10 +144,65 @@ public class ExplorationJournalEventSimulatorTool {
 
             updateMaxBodyIdFromNode(context, node);
 
-            if ("Scan".equals(event) && node.has("PlanetClass")) {
-                buildPlanetFromScan(node).ifPresent(planet -> registerPlanet(context, planet));
+            if ("Scan".equals(event)) {
+                buildBodyNodeFromScan(node, context.lastTimestamp).ifPresent(body -> {
+                    SystemModel model = context.systems.computeIfAbsent(
+                            key(body.starSystem),
+                            k -> new SystemModel(body.starSystem, body.systemAddress)
+                    );
+                    if (model.systemAddress <= 0 && body.systemAddress > 0) {
+                        model.systemAddress = body.systemAddress;
+                    }
+                    model.register(body);
+                    if (body.isPlanetary()) {
+                        registerPlanet(context, new PlanetContext(body.bodyName, body.bodyId, body.starSystem, body.systemAddress));
+                        context.selectedPlanet = body;
+                    }
+                });
             } else if (isPlanetProximityEvent(event, node)) {
-                buildPlanetFromGenericBodyEvent(node).ifPresent(planet -> registerPlanet(context, planet));
+                buildPlanetFromGenericBodyEvent(node).ifPresent(planet -> {
+                    registerPlanet(context, planet);
+                    SystemModel model = context.systems.computeIfAbsent(
+                            key(planet.starSystem),
+                            k -> new SystemModel(planet.starSystem, planet.systemAddress)
+                    );
+                    BodyNode existing = model.getBody(planet.bodyId);
+                    if (existing != null && existing.isPlanetary()) {
+                        context.selectedPlanet = existing;
+                    } else {
+                        BodyNode provisional = new BodyNode(
+                                planet.bodyId,
+                                planet.bodyName,
+                                BodyKind.PLANET,
+                                planet.starSystem,
+                                planet.systemAddress,
+                                model.primaryStarId,
+                                null,
+                                null,
+                                context.lastTimestamp
+                        );
+                        model.register(provisional);
+                        context.selectedPlanet = provisional;
+                    }
+                });
+            } else if ("Docked".equals(event)) {
+                int bodyId = node.path("BodyID").asInt(-1);
+                if (bodyId >= 0 && context.lastDockedStarSystem != null) {
+                    SystemModel dockedModel = context.systems.get(key(context.lastDockedStarSystem));
+                    if (dockedModel != null) {
+                        BodyNode selected = dockedModel.getBody(bodyId);
+                        if (selected != null && selected.isPlanetary()) {
+                            context.selectedPlanet = selected;
+                        }
+                    }
+                }
+            } else if ("ScanOrganic".equals(event)) {
+                long systemAddress = node.path("SystemAddress").asLong(0L);
+                int bodyId = node.path("Body").asInt(-1);
+                String scanType = textValue(node, "ScanType");
+                if (systemAddress > 0 && bodyId >= 0 && scanType != null) {
+                    context.lastOrganicScanTypeByBody.put(organicBodyKey(systemAddress, bodyId), scanType);
+                }
             }
         }
 
@@ -181,26 +239,6 @@ public class ExplorationJournalEventSimulatorTool {
             return false;
         }
         return "Planet".equalsIgnoreCase(node.path("BodyType").asText("")) || node.path("OnPlanet").asBoolean(false);
-    }
-
-    private static Optional<PlanetContext> buildPlanetFromScan(JsonNode node) {
-        if (!node.has("BodyID") || !node.has("StarSystem")) {
-            return Optional.empty();
-        }
-        int bodyId = node.path("BodyID").asInt(-1);
-        if (bodyId < 0) {
-            return Optional.empty();
-        }
-        String starSystem = textValue(node, "StarSystem");
-        if (starSystem == null || starSystem.isBlank()) {
-            return Optional.empty();
-        }
-        long systemAddress = node.path("SystemAddress").asLong(0L);
-        String bodyName = textValue(node, "BodyName");
-        if (bodyName == null || bodyName.isBlank()) {
-            bodyName = starSystem + " Body " + bodyId;
-        }
-        return Optional.of(new PlanetContext(bodyName, bodyId, starSystem, systemAddress));
     }
 
     private static Optional<PlanetContext> buildPlanetFromGenericBodyEvent(JsonNode node) {
@@ -258,7 +296,7 @@ public class ExplorationJournalEventSimulatorTool {
         long systemAddress = parseLongOption(options, "system-address")
                 .orElseGet(() -> generateDifferentAddress(context.currentSystemAddress));
 
-        ObjectNode node = createBaseEvent("FSDJump", context, options);
+        ObjectNode node = createBaseEvent("FSDJump", context);
         node.put("Taxi", false);
         node.put("Multicrew", false);
         node.put("StarSystem", newSystem);
@@ -292,33 +330,433 @@ public class ExplorationJournalEventSimulatorTool {
         String starSystem = options.getOrDefault("system", defaultSystemName(context));
         long systemAddress = parseLongOption(options, "system-address")
                 .orElseGet(() -> resolveSystemAddressForSystem(context, starSystem));
+        SystemModel model = context.systems.computeIfAbsent(
+                key(starSystem),
+                k -> new SystemModel(starSystem, systemAddress)
+        );
+        if (model.systemAddress <= 0) {
+            model.systemAddress = systemAddress;
+        }
+        if (context.currentStarSystem != null && context.currentStarSystem.equalsIgnoreCase(starSystem) && context.currentSystemAddress > 0) {
+            model.systemAddress = context.currentSystemAddress;
+        }
 
-        int bodyId = parseIntOption(options, "body-id")
-                .orElseGet(() -> nextBodyIdForSystem(context, starSystem));
-        String bodyName = options.getOrDefault("body-name", starSystem + " A " + bodyId);
+        GeneratedScanBody generatedBody = generateScanBody(model, options);
 
-        ObjectNode node = createBaseEvent("Scan", context, options);
-        node.put("ScanType", options.getOrDefault("scan-type", "Detailed"));
-        node.put("BodyName", bodyName);
-        node.put("BodyID", bodyId);
+        ObjectNode node = createBaseEvent("Scan", context);
+        node.put("ScanType", generatedBody.scanType);
+        node.put("BodyName", generatedBody.bodyName);
+        node.put("BodyID", generatedBody.bodyId);
 
         ArrayNode parents = node.putArray("Parents");
-        parents.addObject().put("Star", 1);
-        parents.addObject().put("Null", 0);
+        if (generatedBody.kind == BodyKind.STAR) {
+            parents.addObject().put("Null", 0);
+        } else if (generatedBody.kind == BodyKind.PLANET) {
+            parents.addObject().put("Star", generatedBody.starParentId);
+            parents.addObject().put("Null", 0);
+        } else {
+            parents.addObject().put("Planet", generatedBody.planetParentId);
+            parents.addObject().put("Star", generatedBody.starParentId);
+            parents.addObject().put("Null", 0);
+        }
 
+        node.put("StarSystem", model.starSystem);
+        node.put("SystemAddress", model.systemAddress);
+        node.put("DistanceFromArrivalLS", generatedBody.distanceFromArrivalLs);
+
+        if (generatedBody.kind == BodyKind.STAR) {
+            fillStarScanFields(node);
+        } else {
+            fillPlanetScanFields(node, generatedBody.kind == BodyKind.MOON);
+        }
+        model.register(generatedBody.toBodyNode(model.starSystem, model.systemAddress, context.lastTimestamp));
+        return node;
+    }
+
+    private ObjectNode createScanOrganicEvent(JournalContext context, Map<String, String> options) {
+        BodyNode selectedPlanet = resolveSelectedPlanet(context, options)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Aucune planete selectionnee: utilisez --selected-body-id ou scannez/selectionnez une planete avant ScanOrganic"
+                ));
+
+        long systemAddress = parseLongOption(options, "system-address").orElse(selectedPlanet.systemAddress);
+        int bodyId = parseIntOption(options, "body-id").orElse(selectedPlanet.bodyId);
+
+        ObjectNode node = createBaseEvent("ScanOrganic", context);
+        node.put("ScanType", options.getOrDefault("scan-type", nextOrganicScanType(context, selectedPlanet)));
+        node.put("Genus", "$Codex_Ent_Stratum_Genus_Name;");
+        node.put("Genus_Localised", "Stratum");
+        node.put("Species", "$Codex_Ent_Stratum_07_Name;");
+        node.put("Species_Localised", "Stratum Tectonicas");
+        node.put("Variant", "$Codex_Ent_Stratum_07_L_Name;");
+        node.put("Variant_Localised", "Stratum Tectonicas - Turquoise");
+        node.put("WasLogged", false);
+        node.put("SystemAddress", systemAddress);
+        node.put("Body", bodyId);
+        return node;
+    }
+
+    private ObjectNode createDockedEvent(JournalContext context, Map<String, String> options) {
+        BodyNode selectedPlanet = resolveSelectedPlanet(context, options)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Aucune planete selectionnee: utilisez --selected-body-id/--selected-body-name avant Docked"
+                ));
+
+        String starSystem = options.getOrDefault("system", selectedPlanet.starSystem);
+        long systemAddress = parseLongOption(options, "system-address")
+                .orElse(selectedPlanet.systemAddress);
+        String defaultStation = selectedPlanet.bodyName + " Relay";
+
+        ObjectNode node = createBaseEvent("Docked", context);
+        node.put("StationName", options.getOrDefault("station-name", defaultStation));
+        node.put("StationType", options.getOrDefault("station-type", "Coriolis"));
+        node.put("Taxi", false);
+        node.put("Multicrew", false);
         node.put("StarSystem", starSystem);
         node.put("SystemAddress", systemAddress);
-        node.put("DistanceFromArrivalLS", round(randomInRange(30.0, 3200.0), 6));
+        node.put("MarketID", parseLongOption(options, "market-id").orElse(Math.abs(random.nextLong(9_999_999_999L))));
+        node.putObject("StationFaction").put("Name", "Pilots Federation Local Branch");
+        node.put("StationGovernment", "$government_Democracy;");
+        node.put("StationGovernment_Localised", "Democratie");
+        node.put("StationAllegiance", "PilotsFederation");
+
+        ArrayNode services = node.putArray("StationServices");
+        services.add("dock");
+        services.add("autodock");
+        services.add("contacts");
+        services.add("exploration");
+        services.add("stationMenu");
+
+        node.put("StationEconomy", "$economy_HighTech;");
+        node.put("StationEconomy_Localised", "Haute Technologie");
+        node.put("Body", selectedPlanet.bodyName);
+        node.put("BodyID", selectedPlanet.bodyId);
+        node.put("DistFromStarLS", selectedPlanet.distanceFromArrivalLs != null
+                ? round(Math.max(1.0, selectedPlanet.distanceFromArrivalLs + randomInRange(-50.0, 120.0)), 3)
+                : round(randomInRange(15.0, 1200.0), 3));
+        return node;
+    }
+
+    private ObjectNode createBaseEvent(String eventName, JournalContext context) {
+        ObjectNode node = OBJECT_MAPPER.createObjectNode();
+        node.put("timestamp", nextTimestamp(context));
+        node.put("event", eventName);
+        return node;
+    }
+
+    private String nextTimestamp(JournalContext context) {
+        Instant base = context.lastTimestamp == null ? Instant.now() : context.lastTimestamp.plusSeconds(1);
+        return base.truncatedTo(ChronoUnit.SECONDS).toString();
+    }
+
+    private String defaultSystemName(JournalContext context) {
+        if (context.currentStarSystem != null && !context.currentStarSystem.isBlank()) {
+            return context.currentStarSystem;
+        }
+        if (context.lastScannedPlanet != null && context.lastScannedPlanet.starSystem != null) {
+            return context.lastScannedPlanet.starSystem;
+        }
+        return "Simulation Alpha";
+    }
+
+    private long resolveSystemAddressForSystem(JournalContext context, String starSystem) {
+        if (starSystem != null && context.currentStarSystem != null
+                && starSystem.equalsIgnoreCase(context.currentStarSystem)
+                && context.currentSystemAddress > 0) {
+            return context.currentSystemAddress;
+        }
+        SystemModel model = context.systems.get(key(starSystem));
+        if (model != null && model.systemAddress > 0) {
+            return model.systemAddress;
+        }
+        PlanetContext bySystem = context.lastPlanetBySystem.get(key(starSystem));
+        if (bySystem != null && bySystem.systemAddress > 0) {
+            return bySystem.systemAddress;
+        }
+        if (context.lastDockedStarSystem != null && context.lastDockedStarSystem.equalsIgnoreCase(starSystem)
+                && context.lastDockedSystemAddress > 0) {
+            return context.lastDockedSystemAddress;
+        }
+        return generateDifferentAddress(context.currentSystemAddress);
+    }
+
+    private GeneratedScanBody generateScanBody(SystemModel model, Map<String, String> options) {
+        Integer forcedBodyId = parseIntOption(options, "body-id").orElse(null);
+        if (model.starCount() == 0) {
+            return buildFirstStar(model, forcedBodyId);
+        }
+
+        ScanGenerationMode mode = pickScanMode(model);
+        return switch (mode) {
+            case ANOTHER_STAR -> buildAdditionalStar(model, forcedBodyId);
+            case MOON_AROUND_PLANET -> buildMoonAroundPlanet(model, pickMoonParentPlanet(model), forcedBodyId);
+            case MOON_FROM_EXISTING_MOON -> {
+                BodyNode moonReference = pickExistingMoon(model);
+                BodyNode parentPlanet = moonReference != null
+                        ? model.getBody(moonReference.planetParentId)
+                        : null;
+                if (parentPlanet == null || parentPlanet.kind != BodyKind.PLANET) {
+                    yield buildMoonAroundPlanet(model, pickMoonParentPlanet(model), forcedBodyId);
+                }
+                yield buildMoonAroundPlanet(model, parentPlanet, forcedBodyId);
+            }
+            case PLANET_AROUND_STAR, FIRST_STAR -> buildPlanetAroundStar(model, pickStarForPlanet(model), forcedBodyId);
+        };
+    }
+
+    private ScanGenerationMode pickScanMode(SystemModel model) {
+        List<WeightedMode> modes = new ArrayList<>();
+        if (model.starCount() == 0) {
+            return ScanGenerationMode.FIRST_STAR;
+        }
+        int planetCount = model.planetCount();
+        int moonCount = model.moonCount();
+
+        if (planetCount == 0) {
+            modes.add(new WeightedMode(ScanGenerationMode.PLANET_AROUND_STAR, 78));
+            modes.add(new WeightedMode(ScanGenerationMode.ANOTHER_STAR, 22));
+        } else if (moonCount == 0) {
+            modes.add(new WeightedMode(ScanGenerationMode.PLANET_AROUND_STAR, 52));
+            modes.add(new WeightedMode(ScanGenerationMode.ANOTHER_STAR, 14));
+            modes.add(new WeightedMode(ScanGenerationMode.MOON_AROUND_PLANET, 34));
+        } else {
+            modes.add(new WeightedMode(ScanGenerationMode.PLANET_AROUND_STAR, 48));
+            modes.add(new WeightedMode(ScanGenerationMode.ANOTHER_STAR, 14));
+            modes.add(new WeightedMode(ScanGenerationMode.MOON_AROUND_PLANET, 30));
+            modes.add(new WeightedMode(ScanGenerationMode.MOON_FROM_EXISTING_MOON, 8));
+        }
+
+        int total = modes.stream().mapToInt(m -> m.weight).sum();
+        int roll = random.nextInt(total);
+        int cursor = 0;
+        for (WeightedMode mode : modes) {
+            cursor += mode.weight;
+            if (roll < cursor) {
+                return mode.mode;
+            }
+        }
+        return modes.get(modes.size() - 1).mode;
+    }
+
+    private GeneratedScanBody buildFirstStar(SystemModel model, Integer forcedBodyId) {
+        char starLetter = nextStarLetter(model);
+        int bodyId = forcedBodyId != null ? forcedBodyId : model.nextBodyId();
+        String bodyName = model.starSystem + " " + starLetter;
+        return new GeneratedScanBody(
+                bodyId,
+                bodyName,
+                BodyKind.STAR,
+                null,
+                null,
+                "AutoScan",
+                0.0
+        );
+    }
+
+    private GeneratedScanBody buildAdditionalStar(SystemModel model, Integer forcedBodyId) {
+        char starLetter = nextStarLetter(model);
+        int bodyId = forcedBodyId != null ? forcedBodyId : model.nextBodyId();
+        String bodyName = model.starSystem + " " + starLetter;
+        return new GeneratedScanBody(
+                bodyId,
+                bodyName,
+                BodyKind.STAR,
+                null,
+                null,
+                "AutoScan",
+                round(randomInRange(450.0, 160000.0), 6)
+        );
+    }
+
+    private GeneratedScanBody buildPlanetAroundStar(SystemModel model, BodyNode starParent, Integer forcedBodyId) {
+        if (starParent == null) {
+            return buildAdditionalStar(model, forcedBodyId);
+        }
+        char starLetter = readStarLetter(model.starSystem, starParent.bodyName)
+                .orElse('A');
+        int planetIndex = nextPlanetIndexForStar(model, starParent.bodyId, starLetter);
+        int bodyId = forcedBodyId != null ? forcedBodyId : model.nextBodyId();
+        String bodyName = model.starSystem + " " + starLetter + " " + planetIndex;
+        return new GeneratedScanBody(
+                bodyId,
+                bodyName,
+                BodyKind.PLANET,
+                starParent.bodyId,
+                null,
+                "Detailed",
+                round(randomInRange(30.0, 4200.0), 6)
+        );
+    }
+
+    private GeneratedScanBody buildMoonAroundPlanet(SystemModel model, BodyNode planetParent, Integer forcedBodyId) {
+        if (planetParent == null) {
+            return buildPlanetAroundStar(model, pickStarForPlanet(model), forcedBodyId);
+        }
+        Character moonLetter = nextMoonLetterForPlanet(model, planetParent.bodyId);
+        if (moonLetter == null) {
+            moonLetter = 'a';
+        }
+        int bodyId = forcedBodyId != null ? forcedBodyId : model.nextBodyId();
+        Integer starParentId = planetParent.starParentId != null
+                ? planetParent.starParentId
+                : model.primaryStarId;
+        String bodyName = planetParent.bodyName + " " + moonLetter;
+        return new GeneratedScanBody(
+                bodyId,
+                bodyName,
+                BodyKind.MOON,
+                starParentId,
+                planetParent.bodyId,
+                "Detailed",
+                round(Math.max(planetParent.distanceFromArrivalLs != null ? planetParent.distanceFromArrivalLs + randomInRange(0.2, 40.0) : randomInRange(45.0, 4400.0), 1.0), 6)
+        );
+    }
+
+    private BodyNode pickStarForPlanet(SystemModel model) {
+        List<BodyNode> stars = model.stars();
+        if (stars.isEmpty()) {
+            return null;
+        }
+        if (model.primaryStarId != null && random.nextDouble() < 0.72) {
+            BodyNode primary = model.getBody(model.primaryStarId);
+            if (primary != null) {
+                return primary;
+            }
+        }
+        return stars.get(random.nextInt(stars.size()));
+    }
+
+    private BodyNode pickMoonParentPlanet(SystemModel model) {
+        List<BodyNode> planets = model.planets();
+        if (planets.isEmpty()) {
+            return null;
+        }
+        return planets.get(random.nextInt(planets.size()));
+    }
+
+    private BodyNode pickExistingMoon(SystemModel model) {
+        List<BodyNode> moons = model.moons();
+        if (moons.isEmpty()) {
+            return null;
+        }
+        return moons.get(random.nextInt(moons.size()));
+    }
+
+    private char nextStarLetter(SystemModel model) {
+        boolean[] used = new boolean[26];
+        for (BodyNode star : model.stars()) {
+            readStarLetter(model.starSystem, star.bodyName).ifPresent(letter -> {
+                int index = letter - 'A';
+                if (index >= 0 && index < used.length) {
+                    used[index] = true;
+                }
+            });
+        }
+        for (int i = 0; i < used.length; i++) {
+            if (!used[i]) {
+                return (char) ('A' + i);
+            }
+        }
+        return (char) ('A' + random.nextInt(26));
+    }
+
+    private int nextPlanetIndexForStar(SystemModel model, int starBodyId, char starLetter) {
+        int max = 0;
+        for (BodyNode planet : model.planets()) {
+            if (planet.starParentId != null && planet.starParentId == starBodyId) {
+                Optional<Integer> idx = readPlanetIndex(model.starSystem, planet.bodyName, starLetter);
+                if (idx.isPresent()) {
+                    max = Math.max(max, idx.get());
+                }
+            }
+        }
+        return Math.max(1, max + 1);
+    }
+
+    private Character nextMoonLetterForPlanet(SystemModel model, int planetBodyId) {
+        char max = 0;
+        for (BodyNode moon : model.moons()) {
+            if (moon.planetParentId != null && moon.planetParentId == planetBodyId) {
+                char letter = readMoonLetter(moon.bodyName).orElse((char) 0);
+                if (letter > max) {
+                    max = letter;
+                }
+            }
+        }
+        return max == 0 ? 'a' : (max == 'z' ? 'z' : (char) (max + 1));
+    }
+
+    private static Optional<Character> readStarLetter(String starSystem, String bodyName) {
+        if (starSystem == null || bodyName == null) {
+            return Optional.empty();
+        }
+        Pattern p = Pattern.compile("^" + Pattern.quote(starSystem) + " ([A-Z])$");
+        Matcher m = p.matcher(bodyName);
+        if (!m.matches()) {
+            return Optional.empty();
+        }
+        return Optional.of(m.group(1).charAt(0));
+    }
+
+    private static Optional<Integer> readPlanetIndex(String starSystem, String bodyName, char starLetter) {
+        if (starSystem == null || bodyName == null) {
+            return Optional.empty();
+        }
+        Pattern p = Pattern.compile("^" + Pattern.quote(starSystem) + " " + starLetter + " (\\d+)$");
+        Matcher m = p.matcher(bodyName);
+        if (!m.matches()) {
+            return Optional.empty();
+        }
+        return Optional.of(Integer.parseInt(m.group(1)));
+    }
+
+    private static Optional<Character> readMoonLetter(String bodyName) {
+        if (bodyName == null) {
+            return Optional.empty();
+        }
+        Pattern p = Pattern.compile("^.+ [A-Z] \\d+ ([a-z])$");
+        Matcher m = p.matcher(bodyName);
+        if (!m.matches()) {
+            return Optional.empty();
+        }
+        return Optional.of(m.group(1).charAt(0));
+    }
+
+    private void fillStarScanFields(ObjectNode node) {
+        String starType = STAR_TYPES.get(random.nextInt(STAR_TYPES.size()));
+        node.put("StarType", starType);
+        node.put("Subclass", random.nextInt(8));
+        node.put("StellarMass", round(randomInRange(0.08, 2.5), 6));
+        node.put("Radius", round(randomInRange(90_000_000.0, 690_000_000.0), 6));
+        node.put("AbsoluteMagnitude", round(randomInRange(2.0, 14.0), 6));
+        node.put("Age_MY", random.nextInt(13000));
+        node.put("SurfaceTemperature", round(randomInRange(2400.0, 7700.0), 6));
+        node.put("Luminosity", "V");
+        node.put("SemiMajorAxis", randomInRange(1.8E10, 4.1E12));
+        node.put("Eccentricity", round(randomInRange(0.0, 0.4), 6));
+        node.put("OrbitalInclination", round(randomInRange(-80.0, 80.0), 6));
+        node.put("Periapsis", round(randomInRange(0.0, 359.0), 6));
+        node.put("OrbitalPeriod", randomInRange(1_200_000.0, 3_400_000_000.0));
+        node.put("AscendingNode", round(randomInRange(-150.0, 150.0), 6));
+        node.put("MeanAnomaly", round(randomInRange(0.0, 359.0), 6));
+        node.put("RotationPeriod", randomInRange(42000.0, 420000.0));
+        node.put("AxialTilt", 0.0);
+        node.put("WasDiscovered", false);
+        node.put("WasMapped", false);
+        node.put("WasFootfalled", false);
+    }
+
+    private void fillPlanetScanFields(ObjectNode node, boolean moon) {
         node.put("TidalLock", random.nextBoolean());
         node.put("TerraformState", "");
-        node.put("PlanetClass", options.getOrDefault("planet-class", "High metal content body"));
+        node.put("PlanetClass", moon ? "Rocky body" : "High metal content body");
         node.put("Atmosphere", "");
         node.put("AtmosphereType", "None");
         node.put("Volcanism", "");
         node.put("MassEM", round(randomInRange(0.001, 0.008), 6));
         node.put("Radius", round(randomInRange(650000.0, 1450000.0), 6));
-        node.put("SurfaceGravity", round(randomInRange(0.95, 2.15), 6));
-        node.put("SurfaceTemperature", round(randomInRange(90.0, 610.0), 6));
+        node.put("SurfaceGravity", round(randomInRange(0.85, 2.25), 6));
+        node.put("SurfaceTemperature", round(randomInRange(80.0, 650.0), 6));
         node.put("SurfacePressure", 0.0);
         node.put("Landable", true);
 
@@ -352,118 +790,88 @@ public class ExplorationJournalEventSimulatorTool {
         node.put("WasDiscovered", false);
         node.put("WasMapped", false);
         node.put("WasFootfalled", false);
-        return node;
     }
 
-    private ObjectNode createScanOrganicEvent(JournalContext context, Map<String, String> options) {
-        PlanetContext organicTarget = resolveOrganicTargetPlanet(context)
-                .orElseGet(() -> new PlanetContext(
-                        defaultSystemName(context) + " A " + nextBodyIdForSystem(context, defaultSystemName(context)),
-                        nextBodyIdForSystem(context, defaultSystemName(context)),
-                        defaultSystemName(context),
-                        resolveSystemAddressForSystem(context, defaultSystemName(context))
-                ));
-
-        int bodyId = parseIntOption(options, "body-id").orElse(organicTarget.bodyId);
-        long systemAddress = parseLongOption(options, "system-address").orElse(organicTarget.systemAddress);
-
-        ObjectNode node = createBaseEvent("ScanOrganic", context, options);
-        node.put("ScanType", options.getOrDefault("scan-type", "Log"));
-        node.put("Genus", "$Codex_Ent_Stratum_Genus_Name;");
-        node.put("Genus_Localised", "Stratum");
-        node.put("Species", "$Codex_Ent_Stratum_07_Name;");
-        node.put("Species_Localised", "Stratum Tectonicas");
-        node.put("Variant", "$Codex_Ent_Stratum_07_L_Name;");
-        node.put("Variant_Localised", "Stratum Tectonicas - Turquoise");
-        node.put("WasLogged", false);
-        node.put("SystemAddress", systemAddress);
-        node.put("Body", bodyId);
-        return node;
+    private String nextOrganicScanType(JournalContext context, BodyNode selectedPlanet) {
+        String key = organicBodyKey(selectedPlanet.systemAddress, selectedPlanet.bodyId);
+        String last = context.lastOrganicScanTypeByBody.get(key);
+        if (last == null) {
+            return "Log";
+        }
+        return switch (last.toLowerCase(Locale.ROOT)) {
+            case "log" -> "Sample";
+            case "sample" -> "Analyse";
+            default -> "Sample";
+        };
     }
 
-    private ObjectNode createDockedEvent(JournalContext context, Map<String, String> options) {
-        String starSystem = options.getOrDefault("system", defaultSystemName(context));
-        long systemAddress = parseLongOption(options, "system-address")
-                .orElseGet(() -> resolveSystemAddressForSystem(context, starSystem));
-
-        ObjectNode node = createBaseEvent("Docked", context, options);
-        node.put("StationName", options.getOrDefault("station-name", "Warboard Simulation Port"));
-        node.put("StationType", options.getOrDefault("station-type", "Coriolis"));
-        node.put("Taxi", false);
-        node.put("Multicrew", false);
-        node.put("StarSystem", starSystem);
-        node.put("SystemAddress", systemAddress);
-        node.put("MarketID", parseLongOption(options, "market-id").orElse(Math.abs(random.nextLong(9_999_999_999L))));
-        node.putObject("StationFaction").put("Name", "Pilots Federation Local Branch");
-        node.put("StationGovernment", "$government_Democracy;");
-        node.put("StationGovernment_Localised", "Democratie");
-        node.put("StationAllegiance", "PilotsFederation");
-
-        ArrayNode services = node.putArray("StationServices");
-        services.add("dock");
-        services.add("autodock");
-        services.add("contacts");
-        services.add("exploration");
-        services.add("stationMenu");
-
-        node.put("StationEconomy", "$economy_HighTech;");
-        node.put("StationEconomy_Localised", "Haute Technologie");
-        node.put("DistFromStarLS", round(randomInRange(15.0, 1200.0), 3));
-        return node;
-    }
-
-    private Optional<PlanetContext> resolveOrganicTargetPlanet(JournalContext context) {
-        if (context.lastDockedStarSystem != null && !context.lastDockedStarSystem.isBlank()) {
-            PlanetContext fromDockedSystem = context.lastPlanetBySystem.get(key(context.lastDockedStarSystem));
-            if (fromDockedSystem != null) {
-                return Optional.of(fromDockedSystem);
+    private Optional<BodyNode> resolveSelectedPlanet(JournalContext context, Map<String, String> options) {
+        Optional<Integer> selectedBodyIdOpt = parseIntOption(options, "selected-body-id");
+        if (selectedBodyIdOpt.isPresent()) {
+            int bodyId = selectedBodyIdOpt.get();
+            Optional<BodyNode> byId = findBodyById(context, bodyId);
+            if (byId.isPresent() && byId.get().isPlanetary()) {
+                return byId;
             }
         }
-        return Optional.ofNullable(context.lastScannedPlanet);
+
+        String selectedBodyName = options.get("selected-body-name");
+        if (selectedBodyName != null && !selectedBodyName.isBlank()) {
+            Optional<BodyNode> byName = findBodyByName(context, selectedBodyName.trim());
+            if (byName.isPresent() && byName.get().isPlanetary()) {
+                return byName;
+            }
+        }
+
+        if (context.selectedPlanet != null) {
+            return Optional.of(context.selectedPlanet);
+        }
+
+        if (context.currentStarSystem != null) {
+            SystemModel model = context.systems.get(key(context.currentStarSystem));
+            if (model != null) {
+                return model.latestPlanetaryBody();
+            }
+        }
+        return context.findAnyPlanetaryBody();
     }
 
-    private ObjectNode createBaseEvent(String eventName, JournalContext context, Map<String, String> options) {
-        ObjectNode node = OBJECT_MAPPER.createObjectNode();
-        node.put("timestamp", options.getOrDefault("timestamp", nextTimestamp(context)));
-        node.put("event", eventName);
-        return node;
+    private Optional<BodyNode> findBodyById(JournalContext context, int bodyId) {
+        if (context.currentStarSystem != null) {
+            SystemModel current = context.systems.get(key(context.currentStarSystem));
+            if (current != null) {
+                BodyNode body = current.getBody(bodyId);
+                if (body != null) {
+                    return Optional.of(body);
+                }
+            }
+        }
+        for (SystemModel model : context.systems.values()) {
+            BodyNode body = model.getBody(bodyId);
+            if (body != null) {
+                return Optional.of(body);
+            }
+        }
+        return Optional.empty();
     }
 
-    private String nextTimestamp(JournalContext context) {
-        Instant base = context.lastTimestamp == null ? Instant.now() : context.lastTimestamp.plusSeconds(1);
-        return base.truncatedTo(ChronoUnit.SECONDS).toString();
-    }
-
-    private String defaultSystemName(JournalContext context) {
-        if (context.currentStarSystem != null && !context.currentStarSystem.isBlank()) {
-            return context.currentStarSystem;
+    private Optional<BodyNode> findBodyByName(JournalContext context, String bodyName) {
+        if (context.currentStarSystem != null) {
+            SystemModel current = context.systems.get(key(context.currentStarSystem));
+            if (current != null) {
+                Optional<BodyNode> found = current.findBodyByName(bodyName);
+                if (found.isPresent()) {
+                    return found;
+                }
+            }
         }
-        if (context.lastScannedPlanet != null && context.lastScannedPlanet.starSystem != null) {
-            return context.lastScannedPlanet.starSystem;
+        for (SystemModel model : context.systems.values()) {
+            Optional<BodyNode> found = model.findBodyByName(bodyName);
+            if (found.isPresent()) {
+                return found;
+            }
         }
-        return "Simulation Alpha";
-    }
-
-    private long resolveSystemAddressForSystem(JournalContext context, String starSystem) {
-        if (starSystem != null && context.currentStarSystem != null
-                && starSystem.equalsIgnoreCase(context.currentStarSystem)
-                && context.currentSystemAddress > 0) {
-            return context.currentSystemAddress;
-        }
-        PlanetContext bySystem = context.lastPlanetBySystem.get(key(starSystem));
-        if (bySystem != null && bySystem.systemAddress > 0) {
-            return bySystem.systemAddress;
-        }
-        if (context.lastDockedStarSystem != null && context.lastDockedStarSystem.equalsIgnoreCase(starSystem)
-                && context.lastDockedSystemAddress > 0) {
-            return context.lastDockedSystemAddress;
-        }
-        return generateDifferentAddress(context.currentSystemAddress);
-    }
-
-    private int nextBodyIdForSystem(JournalContext context, String starSystem) {
-        int current = context.maxBodyIdBySystem.getOrDefault(key(starSystem), 0);
-        return Math.max(1, current + 1);
+        return Optional.empty();
     }
 
     private String generateNextSystemName(String currentSystem) {
@@ -542,6 +950,58 @@ public class ExplorationJournalEventSimulatorTool {
         return starSystem == null ? "" : starSystem.toLowerCase(Locale.ROOT);
     }
 
+    private static String organicBodyKey(long systemAddress, int bodyId) {
+        return systemAddress + ":" + bodyId;
+    }
+
+    private static Optional<BodyNode> buildBodyNodeFromScan(JsonNode node, Instant timestamp) {
+        int bodyId = node.path("BodyID").asInt(-1);
+        String bodyName = textValue(node, "BodyName");
+        String starSystem = textValue(node, "StarSystem");
+        long systemAddress = node.path("SystemAddress").asLong(0L);
+        if (bodyId < 0 || bodyName == null || starSystem == null || starSystem.isBlank()) {
+            return Optional.empty();
+        }
+
+        Integer starParentId = null;
+        Integer planetParentId = null;
+        JsonNode parents = node.path("Parents");
+        if (parents.isArray()) {
+            for (JsonNode parent : parents) {
+                if (parent.has("Star") && starParentId == null) {
+                    starParentId = parent.path("Star").asInt();
+                } else if (parent.has("Planet") && planetParentId == null) {
+                    planetParentId = parent.path("Planet").asInt();
+                }
+            }
+        }
+
+        BodyKind kind;
+        if (node.has("StarType")) {
+            kind = BodyKind.STAR;
+        } else if (node.has("PlanetClass")) {
+            kind = planetParentId != null ? BodyKind.MOON : BodyKind.PLANET;
+        } else {
+            return Optional.empty();
+        }
+
+        Double distance = node.has("DistanceFromArrivalLS")
+                ? node.path("DistanceFromArrivalLS").asDouble()
+                : null;
+
+        return Optional.of(new BodyNode(
+                bodyId,
+                bodyName,
+                kind,
+                starSystem,
+                systemAddress,
+                starParentId,
+                planetParentId,
+                distance,
+                timestamp
+        ));
+    }
+
     private static String textValue(JsonNode node, String fieldName) {
         if (node == null || fieldName == null) {
             return null;
@@ -577,7 +1037,8 @@ public class ExplorationJournalEventSimulatorTool {
                 Exemples:
                   ... -Dexec.args="fsdjump --journal-dir=elite-warboard-missions/src/main/resources/exemple"
                   ... -Dexec.args="scan --scan-type=Detailed"
-                  ... -Dexec.args="scanorganic --scan-type=Sample"
+                  ... -Dexec.args="scanorganic --scan-type=Sample --selected-body-id=12"
+                  ... -Dexec.args="docked --selected-body-name=Swoilz RE-U c18-3 B 1"
                 """);
     }
 
@@ -640,11 +1101,182 @@ public class ExplorationJournalEventSimulatorTool {
         private String lastDockedStarSystem;
         private long lastDockedSystemAddress;
         private PlanetContext lastScannedPlanet;
+        private BodyNode selectedPlanet;
         private Instant lastTimestamp;
         private final Map<String, PlanetContext> lastPlanetBySystem = new HashMap<>();
         private final Map<String, Integer> maxBodyIdBySystem = new HashMap<>();
+        private final Map<String, SystemModel> systems = new HashMap<>();
+        private final Map<String, String> lastOrganicScanTypeByBody = new HashMap<>();
+
+        private Optional<BodyNode> findAnyPlanetaryBody() {
+            for (SystemModel model : systems.values()) {
+                Optional<BodyNode> body = model.latestPlanetaryBody();
+                if (body.isPresent()) {
+                    return body;
+                }
+            }
+            return Optional.empty();
+        }
     }
 
     private record PlanetContext(String bodyName, int bodyId, String starSystem, long systemAddress) {
+    }
+
+    private enum BodyKind {
+        STAR,
+        PLANET,
+        MOON
+    }
+
+    private enum ScanGenerationMode {
+        FIRST_STAR,
+        PLANET_AROUND_STAR,
+        ANOTHER_STAR,
+        MOON_AROUND_PLANET,
+        MOON_FROM_EXISTING_MOON
+    }
+
+    private record WeightedMode(ScanGenerationMode mode, int weight) {
+    }
+
+    private static final class BodyNode {
+        private final int bodyId;
+        private final String bodyName;
+        private final BodyKind kind;
+        private final String starSystem;
+        private final long systemAddress;
+        private final Integer starParentId;
+        private final Integer planetParentId;
+        private final Double distanceFromArrivalLs;
+        private final Instant timestamp;
+
+        private BodyNode(int bodyId,
+                         String bodyName,
+                         BodyKind kind,
+                         String starSystem,
+                         long systemAddress,
+                         Integer starParentId,
+                         Integer planetParentId,
+                         Double distanceFromArrivalLs,
+                         Instant timestamp) {
+            this.bodyId = bodyId;
+            this.bodyName = bodyName;
+            this.kind = kind;
+            this.starSystem = starSystem;
+            this.systemAddress = systemAddress;
+            this.starParentId = starParentId;
+            this.planetParentId = planetParentId;
+            this.distanceFromArrivalLs = distanceFromArrivalLs;
+            this.timestamp = timestamp;
+        }
+
+        private boolean isPlanetary() {
+            return kind == BodyKind.PLANET || kind == BodyKind.MOON;
+        }
+    }
+
+    private static final class SystemModel {
+        private final String starSystem;
+        private long systemAddress;
+        private int maxBodyId;
+        private Integer primaryStarId;
+        private final Map<Integer, BodyNode> bodiesById = new HashMap<>();
+
+        private SystemModel(String starSystem, long systemAddress) {
+            this.starSystem = starSystem;
+            this.systemAddress = systemAddress;
+        }
+
+        private void register(BodyNode body) {
+            bodiesById.put(body.bodyId, body);
+            maxBodyId = Math.max(maxBodyId, body.bodyId);
+            if (body.kind == BodyKind.STAR) {
+                if (primaryStarId == null) {
+                    primaryStarId = body.bodyId;
+                } else if (readStarLetter(starSystem, body.bodyName).orElse('Z') == 'A') {
+                    primaryStarId = body.bodyId;
+                }
+            }
+        }
+
+        private int nextBodyId() {
+            return Math.max(1, maxBodyId + 1);
+        }
+
+        private int starCount() {
+            return (int) bodiesById.values().stream().filter(b -> b.kind == BodyKind.STAR).count();
+        }
+
+        private int planetCount() {
+            return (int) bodiesById.values().stream().filter(b -> b.kind == BodyKind.PLANET).count();
+        }
+
+        private int moonCount() {
+            return (int) bodiesById.values().stream().filter(b -> b.kind == BodyKind.MOON).count();
+        }
+
+        private List<BodyNode> stars() {
+            return bodiesById.values().stream()
+                    .filter(b -> b.kind == BodyKind.STAR)
+                    .sorted(Comparator.comparingInt(b -> b.bodyId))
+                    .toList();
+        }
+
+        private List<BodyNode> planets() {
+            return bodiesById.values().stream()
+                    .filter(b -> b.kind == BodyKind.PLANET)
+                    .sorted(Comparator.comparingInt(b -> b.bodyId))
+                    .toList();
+        }
+
+        private List<BodyNode> moons() {
+            return bodiesById.values().stream()
+                    .filter(b -> b.kind == BodyKind.MOON)
+                    .sorted(Comparator.comparingInt(b -> b.bodyId))
+                    .toList();
+        }
+
+        private BodyNode getBody(Integer bodyId) {
+            if (bodyId == null) {
+                return null;
+            }
+            return bodiesById.get(bodyId);
+        }
+
+        private Optional<BodyNode> latestPlanetaryBody() {
+            return bodiesById.values().stream()
+                    .filter(BodyNode::isPlanetary)
+                    .max(Comparator.comparing(b -> b.timestamp != null ? b.timestamp : Instant.EPOCH));
+        }
+
+        private Optional<BodyNode> findBodyByName(String bodyName) {
+            return bodiesById.values().stream()
+                    .filter(b -> b.bodyName.equalsIgnoreCase(bodyName))
+                    .findFirst();
+        }
+    }
+
+    private record GeneratedScanBody(
+            int bodyId,
+            String bodyName,
+            BodyKind kind,
+            Integer starParentId,
+            Integer planetParentId,
+            String scanType,
+            double distanceFromArrivalLs
+    ) {
+        BodyNode toBodyNode(String starSystem, long systemAddress, Instant timestamp) {
+            return new BodyNode(
+                    bodyId,
+                    bodyName,
+                    kind,
+                    starSystem,
+                    systemAddress,
+                    starParentId,
+                    planetParentId,
+                    distanceFromArrivalLs,
+                    timestamp
+            );
+        }
     }
 }

--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/tools/ExplorationJournalEventSimulatorTool.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/tools/ExplorationJournalEventSimulatorTool.java
@@ -46,6 +46,58 @@ public class ExplorationJournalEventSimulatorTool {
             "Swoilz", "Dryooe", "Bleia", "Hypua", "Prua", "Trifid"
     );
     private static final List<String> STAR_TYPES = List.of("M", "K", "G", "F", "A");
+    private static final List<OrganicSpeciesProfile> ORGANIC_SPECIES_SEQUENCE = List.of(
+            new OrganicSpeciesProfile(
+                    "$Codex_Ent_Stratum_Genus_Name;",
+                    "Stratum",
+                    "$Codex_Ent_Stratum_07_Name;",
+                    "Stratum Tectonicas",
+                    "$Codex_Ent_Stratum_07_L_Name;",
+                    "Stratum Tectonicas - Turquoise"
+            ),
+            new OrganicSpeciesProfile(
+                    "$Codex_Ent_Fonticulus_Genus_Name;",
+                    "Fonticulua",
+                    "$Codex_Ent_Fonticulus_03_Name;",
+                    "Fonticulua Upupam",
+                    "$Codex_Ent_Fonticulus_03_T_Name;",
+                    "Fonticulua Upupam - Orange"
+            ),
+            new OrganicSpeciesProfile(
+                    "$Codex_Ent_Bacterial_Genus_Name;",
+                    "Bacterium",
+                    "$Codex_Ent_Bacterial_12_Name;",
+                    "Bacterium Aurasus",
+                    "$Codex_Ent_Bacterial_12_A_Name;",
+                    "Bacterium Aurasus - Lime"
+            ),
+            new OrganicSpeciesProfile(
+                    "$Codex_Ent_Shrubs_Genus_Name;",
+                    "Frutexa",
+                    "$Codex_Ent_Shrubs_03_Name;",
+                    "Frutexa Metallicum",
+                    "$Codex_Ent_Shrubs_03_B_Name;",
+                    "Frutexa Metallicum - Teal"
+            )
+    );
+    private static final List<OrganicSignature> ORGANIC_SIGNATURE_POOL = List.of(
+            new OrganicSignature(
+                    "$Codex_Ent_Stratum_Genus_Name;",
+                    "Stratum"
+            ),
+            new OrganicSignature(
+                    "$Codex_Ent_Fonticulus_Genus_Name;",
+                    "Fonticulua"
+            ),
+            new OrganicSignature(
+                    "$Codex_Ent_Bacterial_Genus_Name;",
+                    "Bacterium"
+            ),
+            new OrganicSignature(
+                    "$Codex_Ent_Tussocks_Genus_Name;",
+                    "Touradon"
+            )
+    );
 
     private final Random random;
 
@@ -204,8 +256,32 @@ public class ExplorationJournalEventSimulatorTool {
                 long systemAddress = node.path("SystemAddress").asLong(0L);
                 int bodyId = node.path("Body").asInt(-1);
                 String scanType = textValue(node, "ScanType");
+                String species = textValue(node, "Species");
                 if (systemAddress > 0 && bodyId >= 0 && scanType != null) {
-                    context.lastOrganicScanTypeByBody.put(organicBodyKey(systemAddress, bodyId), scanType);
+                    String bodyKey = organicBodyKey(systemAddress, bodyId);
+                    context.lastOrganicScanTypeByBody.put(bodyKey, scanType);
+                    if (species != null && !species.isBlank()) {
+                        int idx = indexOfSpecies(species);
+                        if (idx >= 0) {
+                            OrganicCycleState state = context.lastOrganicCycleByBody.computeIfAbsent(
+                                    bodyKey, k -> new OrganicCycleState()
+                            );
+                            switch (scanType.toLowerCase(Locale.ROOT)) {
+                                case "sample" -> {
+                                    state.speciesIndex = idx;
+                                    state.nextStep = 2;
+                                }
+                                case "analyse", "analyze" -> {
+                                    state.speciesIndex = (idx + 1) % ORGANIC_SPECIES_SEQUENCE.size();
+                                    state.nextStep = 0;
+                                }
+                                default -> {
+                                    state.speciesIndex = idx;
+                                    state.nextStep = 1;
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -386,14 +462,16 @@ public class ExplorationJournalEventSimulatorTool {
         long systemAddress = parseLongOption(options, "system-address").orElse(selectedPlanet.systemAddress);
         int bodyId = parseIntOption(options, "body-id").orElse(selectedPlanet.bodyId);
 
+        OrganicCycleEvent organicCycle = nextOrganicCycleEvent(context, selectedPlanet);
         ObjectNode node = createBaseEvent("ScanOrganic", context);
-        node.put("ScanType", options.getOrDefault("scan-type", nextOrganicScanType(context, selectedPlanet)));
-        node.put("Genus", "$Codex_Ent_Stratum_Genus_Name;");
-        node.put("Genus_Localised", "Stratum");
-        node.put("Species", "$Codex_Ent_Stratum_07_Name;");
-        node.put("Species_Localised", "Stratum Tectonicas");
-        node.put("Variant", "$Codex_Ent_Stratum_07_L_Name;");
-        node.put("Variant_Localised", "Stratum Tectonicas - Turquoise");
+        node.put("ScanType", options.getOrDefault("scan-type", organicCycle.scanType));
+        OrganicSpeciesProfile profile = organicCycle.speciesProfile;
+        node.put("Genus", profile.genusCodex);
+        node.put("Genus_Localised", profile.genusLocalised);
+        node.put("Species", profile.speciesCodex);
+        node.put("Species_Localised", profile.speciesLocalised);
+        node.put("Variant", profile.variantCodex);
+        node.put("Variant_Localised", profile.variantLocalised);
         node.put("WasLogged", false);
         node.put("SystemAddress", systemAddress);
         node.put("Body", bodyId);
@@ -438,6 +516,58 @@ public class ExplorationJournalEventSimulatorTool {
         node.put("DistFromStarLS", selectedPlanet.distanceFromArrivalLs != null
                 ? round(Math.max(1.0, selectedPlanet.distanceFromArrivalLs + randomInRange(-50.0, 120.0)), 3)
                 : round(randomInRange(15.0, 1200.0), 3));
+        return node;
+    }
+
+    private ObjectNode createFssBodySignalsEvent(JournalContext context, Map<String, String> options) {
+        BodyNode selectedPlanet = resolveSelectedPlanet(context, options)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Aucune planete selectionnee: utilisez --selected-body-id/--selected-body-name avant FSSBodySignals"
+                ));
+
+        long systemAddress = parseLongOption(options, "system-address").orElse(selectedPlanet.systemAddress);
+        int bodyId = parseIntOption(options, "body-id").orElse(selectedPlanet.bodyId);
+        int signalCount = parseIntegerOptionInRange(options, "signal-count", 1, 8)
+                .orElse(random.nextInt(1, 5));
+        boolean geological = options.getOrDefault("signal-type", "biological")
+                .equalsIgnoreCase("geological");
+
+        ObjectNode node = createBaseEvent("FSSBodySignals", context);
+        node.put("BodyName", selectedPlanet.bodyName);
+        node.put("BodyID", bodyId);
+        node.put("SystemAddress", systemAddress);
+        ArrayNode signals = node.putArray("Signals");
+        signals.add(buildSingleSignal(geological, signalCount));
+        return node;
+    }
+
+    private ObjectNode createSaaSignalsFoundEvent(JournalContext context, Map<String, String> options) {
+        BodyNode selectedPlanet = resolveSelectedPlanet(context, options)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Aucune planete selectionnee: utilisez --selected-body-id/--selected-body-name avant SAASignalsFound"
+                ));
+
+        long systemAddress = parseLongOption(options, "system-address").orElse(selectedPlanet.systemAddress);
+        int bodyId = parseIntOption(options, "body-id").orElse(selectedPlanet.bodyId);
+        int signalCount = parseIntegerOptionInRange(options, "signal-count", 1, 8)
+                .orElse(random.nextInt(1, 5));
+        boolean geological = options.getOrDefault("signal-type", "biological")
+                .equalsIgnoreCase("geological");
+
+        ObjectNode node = createBaseEvent("SAASignalsFound", context);
+        node.put("BodyName", selectedPlanet.bodyName);
+        node.put("SystemAddress", systemAddress);
+        node.put("BodyID", bodyId);
+        ArrayNode signals = node.putArray("Signals");
+        signals.add(buildSingleSignal(geological, signalCount));
+        if (!geological) {
+            ArrayNode genuses = node.putArray("Genuses");
+            for (OrganicSignature signature : pickOrganicSignatures(signalCount)) {
+                ObjectNode genus = genuses.addObject();
+                genus.put("Genus", signature.genusCodex);
+                genus.put("Genus_Localised", signature.genusLocalised);
+            }
+        }
         return node;
     }
 
@@ -796,17 +926,28 @@ public class ExplorationJournalEventSimulatorTool {
         node.put("WasFootfalled", false);
     }
 
-    private String nextOrganicScanType(JournalContext context, BodyNode selectedPlanet) {
+    private OrganicCycleEvent nextOrganicCycleEvent(JournalContext context, BodyNode selectedPlanet) {
         String key = organicBodyKey(selectedPlanet.systemAddress, selectedPlanet.bodyId);
-        String last = context.lastOrganicScanTypeByBody.get(key);
-        if (last == null) {
-            return "Log";
+        OrganicCycleState state = context.lastOrganicCycleByBody.computeIfAbsent(key, unused -> new OrganicCycleState());
+        int speciesCount = ORGANIC_SPECIES_SEQUENCE.size();
+        if (speciesCount == 0) {
+            throw new IllegalStateException("Aucune espece organique configuree");
         }
-        return switch (last.toLowerCase(Locale.ROOT)) {
-            case "log" -> "Sample";
-            case "sample" -> "Analyse";
-            default -> "Sample";
+        int speciesIndex = Math.floorMod(state.speciesIndex, speciesCount);
+        OrganicSpeciesProfile profile = ORGANIC_SPECIES_SEQUENCE.get(speciesIndex);
+        String scanType = switch (Math.floorMod(state.nextStep, 3)) {
+            case 0, 1 -> "Sample";
+            default -> "Analyse";
         };
+
+        state.nextStep++;
+        if (state.nextStep >= 3) {
+            state.nextStep = 0;
+            state.speciesIndex = (speciesIndex + 1) % speciesCount;
+        } else {
+            state.speciesIndex = speciesIndex;
+        }
+        return new OrganicCycleEvent(scanType, profile);
     }
 
     private Optional<BodyNode> resolveSelectedPlanet(JournalContext context, Map<String, String> options) {
@@ -929,6 +1070,52 @@ public class ExplorationJournalEventSimulatorTool {
         }
     }
 
+    private static Optional<Integer> parseIntegerOptionInRange(
+            Map<String, String> options,
+            String key,
+            int minInclusive,
+            int maxInclusive
+    ) {
+        Optional<Integer> value = parseIntOption(options, key);
+        if (value.isEmpty()) {
+            return Optional.empty();
+        }
+        int parsed = value.get();
+        if (parsed < minInclusive || parsed > maxInclusive) {
+            throw new IllegalArgumentException(
+                    "Option hors borne --" + key + "=" + parsed
+                            + " (attendu: " + minInclusive + ".." + maxInclusive + ")"
+            );
+        }
+        return Optional.of(parsed);
+    }
+
+    private ObjectNode buildSingleSignal(boolean geological, int count) {
+        ObjectNode signal = OBJECT_MAPPER.createObjectNode();
+        if (geological) {
+            signal.put("Type", "$SAA_SignalType_Geological;");
+            signal.put("Type_Localised", "Geologique");
+        } else {
+            signal.put("Type", "$SAA_SignalType_Biological;");
+            signal.put("Type_Localised", "Biologique");
+        }
+        signal.put("Count", Math.max(1, count));
+        return signal;
+    }
+
+    private List<OrganicSpeciesProfile> pickOrganicSignatures(int signalCount) {
+        if (signalCount <= 0) {
+            return List.of();
+        }
+        int count = Math.min(signalCount, ORGANIC_SPECIES_SEQUENCE.size());
+        int start = random.nextInt(ORGANIC_SPECIES_SEQUENCE.size());
+        List<OrganicSpeciesProfile> signatures = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            signatures.add(ORGANIC_SPECIES_SEQUENCE.get((start + i) % ORGANIC_SPECIES_SEQUENCE.size()));
+        }
+        return signatures;
+    }
+
     private void appendJsonLine(Path journalFile, String jsonLine) throws IOException {
         StringBuilder data = new StringBuilder();
         if (Files.size(journalFile) > 0 && !endsWithLineBreak(journalFile)) {
@@ -1037,12 +1224,16 @@ public class ExplorationJournalEventSimulatorTool {
                   scan
                   scanorganic
                   docked
+                  fssbodysignals
+                  saasignalsfound
 
                 Exemples:
                   ... -Dexec.args="fsdjump --journal-dir=elite-warboard-missions/src/main/resources/exemple"
                   ... -Dexec.args="scan --scan-type=Detailed"
-                  ... -Dexec.args="scanorganic --scan-type=Sample --selected-body-id=12"
+                  ... -Dexec.args="scanorganic --selected-body-id=12"
                   ... -Dexec.args="docked --selected-body-name=Swoilz RE-U c18-3 B 1"
+                  ... -Dexec.args="fssbodysignals --selected-body-id=12 --signal-type=biological"
+                  ... -Dexec.args="saasignalsfound --selected-body-id=12 --signal-count=2"
                 """);
     }
 
@@ -1177,6 +1368,21 @@ public class ExplorationJournalEventSimulatorTool {
         private boolean isPlanetary() {
             return kind == BodyKind.PLANET || kind == BodyKind.MOON;
         }
+    }
+
+    private static final class OrganicCycleState {
+        private int speciesIndex;
+        private int nextStep;
+    }
+
+    private record OrganicSpeciesProfile(
+            String genusCodex,
+            String genusLocalised,
+            String speciesCodex,
+            String speciesLocalised,
+            String variantCodex,
+            String variantLocalised
+    ) {
     }
 
     private static final class SystemModel {

--- a/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/tools/ExplorationJournalEventSimulatorTool.java
+++ b/elite-warboard-missions/src/main/java/be/mirooz/elitedangerous/dashboard/tools/ExplorationJournalEventSimulatorTool.java
@@ -39,6 +39,8 @@ public class ExplorationJournalEventSimulatorTool {
     private static final String EVENT_SCAN = "scan";
     private static final String EVENT_SCAN_ORGANIC = "scanorganic";
     private static final String EVENT_DOCKED = "docked";
+    private static final String EVENT_FSS_BODY_SIGNALS = "fssbodysignals";
+    private static final String EVENT_SAA_SIGNALS_FOUND = "saasignalsfound";
 
     private static final List<String> SYSTEM_PREFIXES = List.of(
             "Swoilz", "Dryooe", "Bleia", "Hypua", "Prua", "Trifid"
@@ -83,6 +85,8 @@ public class ExplorationJournalEventSimulatorTool {
             case EVENT_SCAN -> createScanEvent(context, options);
             case EVENT_SCAN_ORGANIC -> createScanOrganicEvent(context, options);
             case EVENT_DOCKED -> createDockedEvent(context, options);
+            case EVENT_FSS_BODY_SIGNALS -> createFssBodySignalsEvent(context, options);
+            case EVENT_SAA_SIGNALS_FOUND -> createSaaSignalsFoundEvent(context, options);
             default -> throw new IllegalArgumentException("Type d'evenement non supporte: " + eventType);
         };
 

--- a/elite-warboard-missions/src/test/java/be/mirooz/elitedangerous/dashboard/tools/ExplorationJournalEventSimulatorToolTest.java
+++ b/elite-warboard-missions/src/test/java/be/mirooz/elitedangerous/dashboard/tools/ExplorationJournalEventSimulatorToolTest.java
@@ -1,0 +1,98 @@
+package be.mirooz.elitedangerous.dashboard.tools;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ExplorationJournalEventSimulatorToolTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void fsdJumpGenereUnNouveauSystemeDifferentDuCourant() throws Exception {
+        Path log = tempDir.resolve("Journal.2026-04-30T100000.01.log");
+        Files.writeString(log, """
+                { "timestamp":"2026-04-30T10:00:00Z", "event":"FSDJump", "StarSystem":"Swoilz RE-U c18-3", "SystemAddress":910096405410 }
+                """, StandardCharsets.UTF_8);
+
+        ExplorationJournalEventSimulatorTool tool = new ExplorationJournalEventSimulatorTool(new Random(42));
+        tool.simulateAndAppend("fsdjump", tempDir, Map.of());
+
+        JsonNode appended = readLastJsonLine(log);
+        assertEquals("FSDJump", appended.path("event").asText());
+        assertNotEquals("Swoilz RE-U c18-3", appended.path("StarSystem").asText());
+        assertNotEquals(910096405410L, appended.path("SystemAddress").asLong());
+    }
+
+    @Test
+    void scanReprendLeSystemeEtLAdresseCourants() throws Exception {
+        Path log = tempDir.resolve("Journal.2026-04-30T100000.01.log");
+        Files.writeString(log, """
+                { "timestamp":"2026-04-30T10:00:00Z", "event":"FSDJump", "StarSystem":"Swoilz EY-G b41-0", "SystemAddress":684105803617 }
+                """, StandardCharsets.UTF_8);
+
+        ExplorationJournalEventSimulatorTool tool = new ExplorationJournalEventSimulatorTool(new Random(7));
+        tool.simulateAndAppend("scan", tempDir, Map.of());
+
+        JsonNode appended = readLastJsonLine(log);
+        assertEquals("Scan", appended.path("event").asText());
+        assertEquals("Swoilz EY-G b41-0", appended.path("StarSystem").asText());
+        assertEquals(684105803617L, appended.path("SystemAddress").asLong());
+    }
+
+    @Test
+    void scanOrganicCibleLaPlaneteDuDernierSystemeDocke() throws Exception {
+        Path log = tempDir.resolve("Journal.2026-04-30T100000.01.log");
+        Files.writeString(log, """
+                { "timestamp":"2026-04-30T10:00:00Z", "event":"Scan", "BodyName":"Other System A 1", "BodyID":1, "StarSystem":"Other System", "SystemAddress":111, "PlanetClass":"Rocky body" }
+                { "timestamp":"2026-04-30T10:01:00Z", "event":"Scan", "BodyName":"Docked System A 7", "BodyID":7, "StarSystem":"Docked System", "SystemAddress":222, "PlanetClass":"Rocky body" }
+                { "timestamp":"2026-04-30T10:02:00Z", "event":"Docked", "StarSystem":"Docked System", "SystemAddress":222, "StationName":"Port Example", "MarketID":123 }
+                """, StandardCharsets.UTF_8);
+
+        ExplorationJournalEventSimulatorTool tool = new ExplorationJournalEventSimulatorTool(new Random(9));
+        tool.simulateAndAppend("scanorganic", tempDir, Map.of());
+
+        JsonNode appended = readLastJsonLine(log);
+        assertEquals("ScanOrganic", appended.path("event").asText());
+        assertEquals(222L, appended.path("SystemAddress").asLong());
+        assertEquals(7, appended.path("Body").asInt());
+    }
+
+    @Test
+    void ecritureSeFaitDansLeDernierJournalLexicographique() throws Exception {
+        Path oldLog = tempDir.resolve("Journal.2026-04-30T090000.01.log");
+        Path latestLog = tempDir.resolve("Journal.2026-04-30T100000.01.log");
+        Files.writeString(oldLog, "{ \"timestamp\":\"2026-04-30T09:00:00Z\", \"event\":\"Fileheader\" }\n", StandardCharsets.UTF_8);
+        Files.writeString(latestLog, "{ \"timestamp\":\"2026-04-30T10:00:00Z\", \"event\":\"Fileheader\" }\n", StandardCharsets.UTF_8);
+
+        ExplorationJournalEventSimulatorTool tool = new ExplorationJournalEventSimulatorTool(new Random(2));
+        Path updated = tool.simulateAndAppend("docked", tempDir, Map.of());
+
+        assertEquals(latestLog, updated);
+        List<String> oldLines = Files.readAllLines(oldLog, StandardCharsets.UTF_8);
+        List<String> latestLines = Files.readAllLines(latestLog, StandardCharsets.UTF_8);
+        assertEquals(1, oldLines.size());
+        assertTrue(latestLines.size() >= 2);
+    }
+
+    private static JsonNode readLastJsonLine(Path file) throws Exception {
+        List<String> lines = Files.readAllLines(file, StandardCharsets.UTF_8);
+        String last = lines.get(lines.size() - 1);
+        return MAPPER.readTree(last);
+    }
+}

--- a/elite-warboard-missions/src/test/java/be/mirooz/elitedangerous/dashboard/tools/ExplorationJournalEventSimulatorToolTest.java
+++ b/elite-warboard-missions/src/test/java/be/mirooz/elitedangerous/dashboard/tools/ExplorationJournalEventSimulatorToolTest.java
@@ -156,6 +156,45 @@ class ExplorationJournalEventSimulatorToolTest {
     }
 
     @Test
+    void fssBodySignalsEtSaaSignalsFoundSontLiesALaPlaneteSelectionnee() throws Exception {
+        Path log = tempDir.resolve("Journal.2026-04-30T100000.01.log");
+        Files.writeString(log, """
+                { "timestamp":"2026-04-30T10:00:00Z", "event":"FSDJump", "StarSystem":"Swoilz EY-G b41-0", "SystemAddress":684105803617 }
+                { "timestamp":"2026-04-30T10:00:01Z", "event":"Scan", "ScanType":"Detailed", "BodyName":"Swoilz EY-G b41-0 A 1", "BodyID":12, "Parents":[ {"Star":1}, {"Null":0} ], "StarSystem":"Swoilz EY-G b41-0", "SystemAddress":684105803617, "DistanceFromArrivalLS":250.0, "TidalLock":true, "TerraformState":"", "PlanetClass":"Rocky body", "Atmosphere":"", "AtmosphereType":"None", "Volcanism":"", "MassEM":0.01, "Radius":1000000.0, "SurfaceGravity":1.0, "SurfaceTemperature":200.0, "SurfacePressure":0.0, "Landable":true, "Materials":[ {"Name":"iron", "Percent":20.0} ], "Composition":{"Ice":0.0, "Rock":0.7, "Metal":0.3}, "SemiMajorAxis":1000.0, "Eccentricity":0.0, "OrbitalInclination":0.0, "Periapsis":0.0, "OrbitalPeriod":1000.0, "AscendingNode":0.0, "MeanAnomaly":0.0, "RotationPeriod":1000.0, "AxialTilt":0.0, "WasDiscovered":false, "WasMapped":false, "WasFootfalled":false }
+                """, StandardCharsets.UTF_8);
+
+        ExplorationJournalEventSimulatorTool tool = new ExplorationJournalEventSimulatorTool(new Random(8));
+        tool.simulateAndAppend("fssbodysignals", tempDir, Map.of("selected-body-id", "12"));
+        JsonNode fss = readLastJsonLine(log);
+        assertEquals("FSSBodySignals", fss.path("event").asText());
+        assertEquals("Swoilz EY-G b41-0 A 1", fss.path("BodyName").asText());
+        assertEquals(12, fss.path("BodyID").asInt());
+        assertEquals(684105803617L, fss.path("SystemAddress").asLong());
+
+        tool.simulateAndAppend("saasignalsfound", tempDir, Map.of("selected-body-id", "12"));
+        JsonNode saa = readLastJsonLine(log);
+        assertEquals("SAASignalsFound", saa.path("event").asText());
+        assertEquals("Swoilz EY-G b41-0 A 1", saa.path("BodyName").asText());
+        assertEquals(12, saa.path("BodyID").asInt());
+        assertEquals(684105803617L, saa.path("SystemAddress").asLong());
+        assertTrue(saa.path("Genuses").isArray());
+        assertTrue(saa.path("Genuses").size() > 0);
+    }
+
+    @Test
+    void fssBodySignalsEtSaaSignalsFoundExigentPlaneteSelectionnee() throws Exception {
+        Path log = tempDir.resolve("Journal.2026-04-30T100000.01.log");
+        Files.writeString(log, """
+                { "timestamp":"2026-04-30T10:00:00Z", "event":"FSDJump", "StarSystem":"Swoilz EY-G b41-0", "SystemAddress":684105803617 }
+                { "timestamp":"2026-04-30T10:00:01Z", "event":"Scan", "ScanType":"AutoScan", "BodyName":"Swoilz EY-G b41-0 A", "BodyID":1, "Parents":[ {"Null":0} ], "StarSystem":"Swoilz EY-G b41-0", "SystemAddress":684105803617, "DistanceFromArrivalLS":0.0, "StarType":"M", "Subclass":3, "StellarMass":0.3, "Radius":300000000.0, "AbsoluteMagnitude":9.1, "Age_MY":1000, "SurfaceTemperature":3000.0, "Luminosity":"V", "SemiMajorAxis":1000000000.0, "Eccentricity":0.0, "OrbitalInclination":0.0, "Periapsis":0.0, "OrbitalPeriod":1000.0, "AscendingNode":0.0, "MeanAnomaly":0.0, "RotationPeriod":1000.0, "AxialTilt":0.0, "WasDiscovered":false, "WasMapped":false, "WasFootfalled":false }
+                """, StandardCharsets.UTF_8);
+
+        ExplorationJournalEventSimulatorTool tool = new ExplorationJournalEventSimulatorTool(new Random(4));
+        assertThrows(IllegalArgumentException.class, () -> tool.simulateAndAppend("fssbodysignals", tempDir, Map.of()));
+        assertThrows(IllegalArgumentException.class, () -> tool.simulateAndAppend("saasignalsfound", tempDir, Map.of()));
+    }
+
+    @Test
     void ecritureSeFaitDansLeDernierJournalLexicographique() throws Exception {
         Path oldLog = tempDir.resolve("Journal.2026-04-30T090000.01.log");
         Path latestLog = tempDir.resolve("Journal.2026-04-30T100000.01.log");

--- a/elite-warboard-missions/src/test/java/be/mirooz/elitedangerous/dashboard/tools/ExplorationJournalEventSimulatorToolTest.java
+++ b/elite-warboard-missions/src/test/java/be/mirooz/elitedangerous/dashboard/tools/ExplorationJournalEventSimulatorToolTest.java
@@ -11,9 +11,11 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ExplorationJournalEventSimulatorToolTest {
@@ -40,37 +42,117 @@ class ExplorationJournalEventSimulatorToolTest {
     }
 
     @Test
-    void scanReprendLeSystemeEtLAdresseCourants() throws Exception {
+    void timestampEstToujoursLeDernierPlusUneSeconde() throws Exception {
         Path log = tempDir.resolve("Journal.2026-04-30T100000.01.log");
         Files.writeString(log, """
                 { "timestamp":"2026-04-30T10:00:00Z", "event":"FSDJump", "StarSystem":"Swoilz EY-G b41-0", "SystemAddress":684105803617 }
                 """, StandardCharsets.UTF_8);
 
         ExplorationJournalEventSimulatorTool tool = new ExplorationJournalEventSimulatorTool(new Random(7));
+        tool.simulateAndAppend("scan", tempDir, Map.of("timestamp", "2099-01-01T00:00:00Z"));
+
+        JsonNode appended = readLastJsonLine(log);
+        assertEquals("2026-04-30T10:00:01Z", appended.path("timestamp").asText());
+    }
+
+    @Test
+    void premierScanDuSystemeEstToujoursUneEtoileAvecNomCoherent() throws Exception {
+        Path log = tempDir.resolve("Journal.2026-04-30T100000.01.log");
+        Files.writeString(log, """
+                { "timestamp":"2026-04-30T10:00:00Z", "event":"FSDJump", "StarSystem":"Swoilz EY-G b41-0", "SystemAddress":684105803617 }
+                """, StandardCharsets.UTF_8);
+
+        ExplorationJournalEventSimulatorTool tool = new ExplorationJournalEventSimulatorTool(new Random(9));
         tool.simulateAndAppend("scan", tempDir, Map.of());
 
         JsonNode appended = readLastJsonLine(log);
         assertEquals("Scan", appended.path("event").asText());
-        assertEquals("Swoilz EY-G b41-0", appended.path("StarSystem").asText());
-        assertEquals(684105803617L, appended.path("SystemAddress").asLong());
+        assertTrue(appended.has("StarType"));
+        assertTrue(Pattern.compile("^Swoilz EY-G b41-0 [A-Z]$").matcher(appended.path("BodyName").asText()).matches());
     }
 
     @Test
-    void scanOrganicCibleLaPlaneteDuDernierSystemeDocke() throws Exception {
+    void scansSuivantsRespectentUneHierarchieClassiqueSansSublune() throws Exception {
         Path log = tempDir.resolve("Journal.2026-04-30T100000.01.log");
         Files.writeString(log, """
-                { "timestamp":"2026-04-30T10:00:00Z", "event":"Scan", "BodyName":"Other System A 1", "BodyID":1, "StarSystem":"Other System", "SystemAddress":111, "PlanetClass":"Rocky body" }
-                { "timestamp":"2026-04-30T10:01:00Z", "event":"Scan", "BodyName":"Docked System A 7", "BodyID":7, "StarSystem":"Docked System", "SystemAddress":222, "PlanetClass":"Rocky body" }
-                { "timestamp":"2026-04-30T10:02:00Z", "event":"Docked", "StarSystem":"Docked System", "SystemAddress":222, "StationName":"Port Example", "MarketID":123 }
+                { "timestamp":"2026-04-30T10:00:00Z", "event":"FSDJump", "StarSystem":"Swoilz EY-G b41-0", "SystemAddress":684105803617 }
                 """, StandardCharsets.UTF_8);
 
-        ExplorationJournalEventSimulatorTool tool = new ExplorationJournalEventSimulatorTool(new Random(9));
-        tool.simulateAndAppend("scanorganic", tempDir, Map.of());
+        ExplorationJournalEventSimulatorTool tool = new ExplorationJournalEventSimulatorTool(new Random(2));
+        tool.simulateAndAppend("scan", tempDir, Map.of()); // first: star
+        tool.simulateAndAppend("scan", tempDir, Map.of());
+        tool.simulateAndAppend("scan", tempDir, Map.of());
+        tool.simulateAndAppend("scan", tempDir, Map.of());
 
-        JsonNode appended = readLastJsonLine(log);
-        assertEquals("ScanOrganic", appended.path("event").asText());
-        assertEquals(222L, appended.path("SystemAddress").asLong());
-        assertEquals(7, appended.path("Body").asInt());
+        List<JsonNode> scans = readScanLines(log);
+        assertTrue(scans.size() >= 4);
+        JsonNode first = scans.get(0);
+        assertTrue(first.has("StarType"));
+
+        for (int i = 1; i < scans.size(); i++) {
+            JsonNode scan = scans.get(i);
+            String bodyName = scan.path("BodyName").asText();
+            JsonNode parents = scan.path("Parents");
+
+            if (scan.has("StarType")) {
+                assertTrue(Pattern.compile("^Swoilz EY-G b41-0 [A-Z]$").matcher(bodyName).matches());
+                continue;
+            }
+
+            if (!parents.isArray() || parents.isEmpty()) {
+                throw new AssertionError("Parents manquant pour body " + bodyName);
+            }
+
+            boolean hasPlanetParent = false;
+            for (JsonNode parent : parents) {
+                if (parent.has("Planet")) {
+                    hasPlanetParent = true;
+                    break;
+                }
+            }
+            if (hasPlanetParent) {
+                // lune: "<system> <StarLetter> <n> <letter>"
+                assertTrue(Pattern.compile("^Swoilz EY-G b41-0 [A-Z] \\d+ [a-z]$").matcher(bodyName).matches());
+            } else {
+                // planète: "<system> <StarLetter> <n>"
+                assertTrue(Pattern.compile("^Swoilz EY-G b41-0 [A-Z] \\d+$").matcher(bodyName).matches());
+            }
+        }
+    }
+
+    @Test
+    void dockedEtScanOrganicExigentUnePlaneteSelectionnee() throws Exception {
+        Path log = tempDir.resolve("Journal.2026-04-30T100000.01.log");
+        Files.writeString(log, """
+                { "timestamp":"2026-04-30T10:00:00Z", "event":"FSDJump", "StarSystem":"Swoilz EY-G b41-0", "SystemAddress":684105803617 }
+                { "timestamp":"2026-04-30T10:00:01Z", "event":"Scan", "ScanType":"AutoScan", "BodyName":"Swoilz EY-G b41-0 A", "BodyID":1, "Parents":[ {"Null":0} ], "StarSystem":"Swoilz EY-G b41-0", "SystemAddress":684105803617, "DistanceFromArrivalLS":0.0, "StarType":"M", "Subclass":3, "StellarMass":0.3, "Radius":300000000.0, "AbsoluteMagnitude":9.1, "Age_MY":1000, "SurfaceTemperature":3000.0, "Luminosity":"V", "SemiMajorAxis":1000000000.0, "Eccentricity":0.0, "OrbitalInclination":0.0, "Periapsis":0.0, "OrbitalPeriod":1000.0, "AscendingNode":0.0, "MeanAnomaly":0.0, "RotationPeriod":1000.0, "AxialTilt":0.0, "WasDiscovered":false, "WasMapped":false, "WasFootfalled":false }
+                """, StandardCharsets.UTF_8);
+
+        ExplorationJournalEventSimulatorTool tool = new ExplorationJournalEventSimulatorTool(new Random(3));
+        assertThrows(IllegalArgumentException.class, () -> tool.simulateAndAppend("docked", tempDir, Map.of()));
+        assertThrows(IllegalArgumentException.class, () -> tool.simulateAndAppend("scanorganic", tempDir, Map.of()));
+    }
+
+    @Test
+    void dockedEtScanOrganicUtilisentLaPlaneteSelectionnee() throws Exception {
+        Path log = tempDir.resolve("Journal.2026-04-30T100000.01.log");
+        Files.writeString(log, """
+                { "timestamp":"2026-04-30T10:00:00Z", "event":"FSDJump", "StarSystem":"Swoilz EY-G b41-0", "SystemAddress":684105803617 }
+                { "timestamp":"2026-04-30T10:00:01Z", "event":"Scan", "ScanType":"Detailed", "BodyName":"Swoilz EY-G b41-0 A 1", "BodyID":12, "Parents":[ {"Star":1}, {"Null":0} ], "StarSystem":"Swoilz EY-G b41-0", "SystemAddress":684105803617, "DistanceFromArrivalLS":250.0, "TidalLock":true, "TerraformState":"", "PlanetClass":"Rocky body", "Atmosphere":"", "AtmosphereType":"None", "Volcanism":"", "MassEM":0.01, "Radius":1000000.0, "SurfaceGravity":1.0, "SurfaceTemperature":200.0, "SurfacePressure":0.0, "Landable":true, "Materials":[ {"Name":"iron", "Percent":20.0} ], "Composition":{"Ice":0.0, "Rock":0.7, "Metal":0.3}, "SemiMajorAxis":1000.0, "Eccentricity":0.0, "OrbitalInclination":0.0, "Periapsis":0.0, "OrbitalPeriod":1000.0, "AscendingNode":0.0, "MeanAnomaly":0.0, "RotationPeriod":1000.0, "AxialTilt":0.0, "WasDiscovered":false, "WasMapped":false, "WasFootfalled":false }
+                """, StandardCharsets.UTF_8);
+
+        ExplorationJournalEventSimulatorTool tool = new ExplorationJournalEventSimulatorTool(new Random(6));
+        tool.simulateAndAppend("docked", tempDir, Map.of("selected-body-id", "12"));
+        JsonNode docked = readLastJsonLine(log);
+        assertEquals("Docked", docked.path("event").asText());
+        assertEquals("Swoilz EY-G b41-0 A 1", docked.path("Body").asText());
+        assertEquals(12, docked.path("BodyID").asInt());
+
+        tool.simulateAndAppend("scanorganic", tempDir, Map.of("selected-body-id", "12"));
+        JsonNode organic = readLastJsonLine(log);
+        assertEquals("ScanOrganic", organic.path("event").asText());
+        assertEquals(684105803617L, organic.path("SystemAddress").asLong());
+        assertEquals(12, organic.path("Body").asInt());
     }
 
     @Test
@@ -78,10 +160,13 @@ class ExplorationJournalEventSimulatorToolTest {
         Path oldLog = tempDir.resolve("Journal.2026-04-30T090000.01.log");
         Path latestLog = tempDir.resolve("Journal.2026-04-30T100000.01.log");
         Files.writeString(oldLog, "{ \"timestamp\":\"2026-04-30T09:00:00Z\", \"event\":\"Fileheader\" }\n", StandardCharsets.UTF_8);
-        Files.writeString(latestLog, "{ \"timestamp\":\"2026-04-30T10:00:00Z\", \"event\":\"Fileheader\" }\n", StandardCharsets.UTF_8);
+        Files.writeString(latestLog, """
+                { "timestamp":"2026-04-30T10:00:00Z", "event":"Fileheader" }
+                { "timestamp":"2026-04-30T10:00:01Z", "event":"Scan", "ScanType":"Detailed", "BodyName":"Swoilz EY-G b41-0 A 1", "BodyID":12, "Parents":[ {"Star":1}, {"Null":0} ], "StarSystem":"Swoilz EY-G b41-0", "SystemAddress":684105803617, "DistanceFromArrivalLS":250.0, "TidalLock":true, "TerraformState":"", "PlanetClass":"Rocky body", "Atmosphere":"", "AtmosphereType":"None", "Volcanism":"", "MassEM":0.01, "Radius":1000000.0, "SurfaceGravity":1.0, "SurfaceTemperature":200.0, "SurfacePressure":0.0, "Landable":true, "Materials":[ {"Name":"iron", "Percent":20.0} ], "Composition":{"Ice":0.0, "Rock":0.7, "Metal":0.3}, "SemiMajorAxis":1000.0, "Eccentricity":0.0, "OrbitalInclination":0.0, "Periapsis":0.0, "OrbitalPeriod":1000.0, "AscendingNode":0.0, "MeanAnomaly":0.0, "RotationPeriod":1000.0, "AxialTilt":0.0, "WasDiscovered":false, "WasMapped":false, "WasFootfalled":false }
+                """, StandardCharsets.UTF_8);
 
         ExplorationJournalEventSimulatorTool tool = new ExplorationJournalEventSimulatorTool(new Random(2));
-        Path updated = tool.simulateAndAppend("docked", tempDir, Map.of());
+        Path updated = tool.simulateAndAppend("docked", tempDir, Map.of("selected-body-id", "12"));
 
         assertEquals(latestLog, updated);
         List<String> oldLines = Files.readAllLines(oldLog, StandardCharsets.UTF_8);
@@ -94,5 +179,19 @@ class ExplorationJournalEventSimulatorToolTest {
         List<String> lines = Files.readAllLines(file, StandardCharsets.UTF_8);
         String last = lines.get(lines.size() - 1);
         return MAPPER.readTree(last);
+    }
+
+    private static List<JsonNode> readScanLines(Path file) throws Exception {
+        List<String> lines = Files.readAllLines(file, StandardCharsets.UTF_8);
+        return lines.stream()
+                .map(line -> {
+                    try {
+                        return MAPPER.readTree(line);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .filter(node -> "Scan".equals(node.path("event").asText()))
+                .toList();
     }
 }

--- a/elite-warboard-missions/src/test/java/be/mirooz/elitedangerous/dashboard/tools/ExplorationJournalEventSimulatorToolTest.java
+++ b/elite-warboard-missions/src/test/java/be/mirooz/elitedangerous/dashboard/tools/ExplorationJournalEventSimulatorToolTest.java
@@ -156,6 +156,40 @@ class ExplorationJournalEventSimulatorToolTest {
     }
 
     @Test
+    void scanOrganicFaitCycleSampleSampleAnalysePuisChangeDEspece() throws Exception {
+        Path log = tempDir.resolve("Journal.2026-04-30T100000.01.log");
+        Files.writeString(log, """
+                { "timestamp":"2026-04-30T10:00:00Z", "event":"FSDJump", "StarSystem":"Swoilz EY-G b41-0", "SystemAddress":684105803617 }
+                { "timestamp":"2026-04-30T10:00:01Z", "event":"Scan", "ScanType":"Detailed", "BodyName":"Swoilz EY-G b41-0 A 1", "BodyID":12, "Parents":[ {"Star":1}, {"Null":0} ], "StarSystem":"Swoilz EY-G b41-0", "SystemAddress":684105803617, "DistanceFromArrivalLS":250.0, "TidalLock":true, "TerraformState":"", "PlanetClass":"Rocky body", "Atmosphere":"", "AtmosphereType":"None", "Volcanism":"", "MassEM":0.01, "Radius":1000000.0, "SurfaceGravity":1.0, "SurfaceTemperature":200.0, "SurfacePressure":0.0, "Landable":true, "Materials":[ {"Name":"iron", "Percent":20.0} ], "Composition":{"Ice":0.0, "Rock":0.7, "Metal":0.3}, "SemiMajorAxis":1000.0, "Eccentricity":0.0, "OrbitalInclination":0.0, "Periapsis":0.0, "OrbitalPeriod":1000.0, "AscendingNode":0.0, "MeanAnomaly":0.0, "RotationPeriod":1000.0, "AxialTilt":0.0, "WasDiscovered":false, "WasMapped":false, "WasFootfalled":false }
+                """, StandardCharsets.UTF_8);
+
+        ExplorationJournalEventSimulatorTool tool = new ExplorationJournalEventSimulatorTool(new Random(11));
+
+        tool.simulateAndAppend("scanorganic", tempDir, Map.of("selected-body-id", "12"));
+        JsonNode e1 = readLastJsonLine(log);
+        String species1 = e1.path("Species").asText();
+        String variant1 = e1.path("Variant").asText();
+        assertEquals("Sample", e1.path("ScanType").asText());
+
+        tool.simulateAndAppend("scanorganic", tempDir, Map.of("selected-body-id", "12"));
+        JsonNode e2 = readLastJsonLine(log);
+        assertEquals("Sample", e2.path("ScanType").asText());
+        assertEquals(species1, e2.path("Species").asText());
+        assertEquals(variant1, e2.path("Variant").asText());
+
+        tool.simulateAndAppend("scanorganic", tempDir, Map.of("selected-body-id", "12"));
+        JsonNode e3 = readLastJsonLine(log);
+        assertEquals("Analyse", e3.path("ScanType").asText());
+        assertEquals(species1, e3.path("Species").asText());
+        assertEquals(variant1, e3.path("Variant").asText());
+
+        tool.simulateAndAppend("scanorganic", tempDir, Map.of("selected-body-id", "12"));
+        JsonNode e4 = readLastJsonLine(log);
+        assertEquals("Sample", e4.path("ScanType").asText());
+        assertNotEquals(species1, e4.path("Species").asText());
+    }
+
+    @Test
     void fssBodySignalsEtSaaSignalsFoundSontLiesALaPlaneteSelectionnee() throws Exception {
         Path log = tempDir.resolve("Journal.2026-04-30T100000.01.log");
         Files.writeString(log, """


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Ajout d'un outil CLI `ExplorationJournalEventSimulatorTool` dans `elite-warboard-missions` pour simuler des lignes d'événements exploration et les écrire dans le **dernier** `Journal.*.log` existant.

Fonctionnalités livrées :
- simulation des événements `fsdjump`, `scan`, `scanorganic`, `docked`, `fssbodysignals`, `saasignalsfound`
- détection du dernier fichier journal du dossier cible
- ajout d'une ligne JSON en fin de fichier (append)

Renforcement de la cohérence structurelle :
- timestamp généré automatiquement à `dernier_timestamp + 1 seconde` (sans override CLI)
- premier `Scan` d'un système forcé sur une **étoile**
- scans suivants générés avec une hiérarchie réaliste :
  - autre étoile,
  - planète orbitant une étoile,
  - lune orbitant une planète,
  - lune basée sur une lune existante mais rattachée à une **planète** (pas de sublune)
- nomenclature des body names alignée sur les journaux :
  - étoile : `<System> <Letter>`
  - planète : `<System> <Letter> <Index>`
  - lune : `<System> <Letter> <Index> <lowercase>`
- `Docked`, `ScanOrganic`, `FSSBodySignals`, `SAASignalsFound` exigent une planète sélectionnée (`--selected-body-id` / `--selected-body-name` ou contexte de sélection disponible)
- ces événements se basent sur la planète sélectionnée (`Body`/`BodyID`/`BodyName`/`SystemAddress` cohérents)

Règle métier ajoutée pour `ScanOrganic` :
- pour une planète donnée, le cycle est forcé sur **la même espèce** :
  1. `Sample`
  2. `Sample`
  3. `Analyse`
- au 4e clic, on recommence un cycle sur **une autre espèce**

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation or other (no code change)

## Related issues

Fixes #(issue number)  
(Optional) Relates to #(issue number)

## Checklist

- [x] My code follows the existing style of the project
- [ ] I have run `mvn clean install` successfully
- [ ] I have tested my changes (e.g. ran the app and verified behavior)
- [ ] For UI or user-facing text: I updated `messages_en.properties` and `messages_fr.properties` if needed

## Screenshots or notes (optional)

Tests ajoutés/mis à jour pour couvrir :
- timestamp `+1s`
- premier scan étoile
- hiérarchie de scans (star/planet/moon sans sublune)
- contrainte de sélection planète pour `Docked`/`ScanOrganic`/`FSSBodySignals`/`SAASignalsFound`
- cycle `ScanOrganic` : `Sample`, `Sample`, `Analyse` puis espèce suivante
- cohérence des champs `Body`/`BodyID`/`BodyName`/`SystemAddress`.

Note: l'exécution des builds/tests complets sur cette machine reste bloquée en amont par un problème d'environnement JavaFX dans `elite-commons` (`javafx.beans.property` introuvable), indépendant de ce changement.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b2c4d2f-5952-4158-bde5-03a6780f8a9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b2c4d2f-5952-4158-bde5-03a6780f8a9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

